### PR TITLE
Negative range counts for arrays set to 0

### DIFF
--- a/test/pass/cpp/stack_static_members_array.cpp
+++ b/test/pass/cpp/stack_static_members_array.cpp
@@ -1,0 +1,18 @@
+// RUN: %cpp-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+struct S {
+  static int a[];
+};
+
+void bar() {
+  S struct_variable;
+}
+
+int S::a[10];  // def, complete type
+
+// CHECK:       - Name:            a
+// CHECK-NEXT:         Builtin:         true
+// CHECK-NEXT:         Type:
+// CHECK-NEXT:           Fundamental:     { Name: int, Extent: 4, Encoding: signed_int }
+// CHECK-NEXT:           Array:           [ 0 ]
+// CHECK-NEXT:           Qualifiers:      [ array, static ]


### PR DESCRIPTION
#### Summary of the Issue

Declarations like `static int a[];` will have `!DISubrange(count: -1)` causing an overflow for the range_count query.

##### Implemented Solution
If value is negative, set to array.subrange to 0.
