### PR TITLE
Byte offset GEP handling

### DIFF
--- a/lib/type/DIFinder.cpp
+++ b/lib/type/DIFinder.cpp
@@ -71,13 +71,16 @@ std::optional<const llvm::DbgVariableIntrinsic*> find_intrinsic(const llvm::Inst
 #else
 
 std::optional<const llvm::DbgVariableRecord*> find_intrinsic(const llvm::Instruction* root) {
-  for (auto const& inst : *root->getParent()) {
+  auto& func = *root->getFunction();
+  for (auto const& inst : llvm::instructions(func)) {
     for (llvm::DbgVariableRecord& var : filterDbgVars(inst.getDbgRecordRange())) {
-      if (compat::get_alloca_for(&var) == root)
+      // LOG_DEBUG(var)
+      if (compat::get_alloca_for(&var) == root) {
+        // LOG_DEBUG(var)
         return &var;
+      }
     }
   }
-
   return {};
 }
 

--- a/test/pass/c/heap_matrix_typeart.c
+++ b/test/pass/c/heap_matrix_typeart.c
@@ -1,0 +1,42 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+#include <stdlib.h>
+#include <string.h>
+typedef struct mat_t {
+  double* vals;
+  int dim[2];
+} mat;
+
+int multiply(mat a, mat b, mat result) {
+  int rows = a.dim[0];
+  int cols = b.dim[1];
+
+  int n = a.dim[1];
+
+  if (n != b.dim[0] || result.dim[0] != rows || result.dim[1] != cols)
+    return 0;
+
+  int num_vals = rows * cols;
+  double* temp = malloc(num_vals * sizeof(double));
+
+  for (int i = 0; i < rows; i++) {
+    for (int j = 0; j < cols; j++) {
+      double val = 0;
+      for (int k = 0; k < n; k++) {
+        val += a.vals[i * cols + k] * b.vals[k * cols + j];
+      }
+      temp[i * cols + j] = val;
+    }
+  }
+
+  // memcpy(result.vals, temp, num_vals);
+  free(temp);
+
+  return 1;
+}
+
+// CHECK: Line:            20
+// CHECK-NEXT: Builtin:         true
+// CHECK-NEXT: Type:
+// CHECK-NEXT:   Fundamental:     { Name: double, Extent: 8, Encoding: float }
+// CHECK-NEXT:   Qualifiers:      [ ptr ]


### PR DESCRIPTION
- Search for DbgVariableRecord in whole function
- DestructureGepIndex does not recurse further for pointer/array-like struct members
- Remove original byte offset calculation, handled by DestructureGepIndex now