### PR TITLE
Fix GEP inlined operator check

### DIFF
--- a/lib/type/DimetaParse.cpp
+++ b/lib/type/DimetaParse.cpp
@@ -95,7 +95,7 @@ inline Qualifier dwarf2qual(unsigned tag) {
     default:
       return Qualifier::kNone;
   }
-};
+}
 
 inline Qualifiers make_qualifiers(const llvm::SmallVector<unsigned, 8>& tag_collector) {
   llvm::SmallVector<unsigned, 8> dwarf_quals;

--- a/test/pass/cpp/heap_inlined_op.cpp
+++ b/test/pass/cpp/heap_inlined_op.cpp
@@ -1,0 +1,20 @@
+
+// RUN: %cpp-to-llvm %s | %opt -O1 -S | %apply-verifier 2>&1 | %filecheck %s
+
+extern "C" {
+void* malloc(int);
+}
+
+struct ArrayWrapper {
+  int** data;
+
+  inline __attribute__((always_inline)) int** operator[](int index) {
+    return &data[index];
+  }
+};
+
+void foo(ArrayWrapper& wrapper) {
+  // CHECK: Final Type: {{.*}} = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  // CHECK-NEXT: Pointer level: 1 (T*)
+  *wrapper[1] = (int*)malloc(sizeof(int));
+}

--- a/test/pass/gep/gep_pointer_to_member.cpp
+++ b/test/pass/gep/gep_pointer_to_member.cpp
@@ -1,0 +1,29 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier 2>&1 | %filecheck %s
+
+// XFAIL: *
+
+// CHECK-NOT: Assertion
+
+extern "C" {
+void* malloc(int);
+}
+
+struct B {
+  double* x;
+};
+
+struct A {
+  float b;
+  float c;
+  B bs;
+};
+
+A k_astruct;
+B k_bstruct;
+
+// Use a pointer to member variable (A::*ptr)
+void foo(A* ar, B A::*member_pointer) {
+  // CHECK: Final Type: {{.*}} = !DIBasicType(name: "double",
+  (ar->*member_pointer).x = static_cast<double*>(malloc(sizeof(double)));
+}

--- a/test/pass/gep/gep_pointer_to_member_fwd.cpp
+++ b/test/pass/gep/gep_pointer_to_member_fwd.cpp
@@ -1,0 +1,27 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier 2>&1 | %filecheck %s
+
+// XFAIL: *
+
+// CHECK-NOT: Assertion
+
+extern "C" {
+void* malloc(int);
+}
+
+struct B {
+  double* x;
+};
+
+struct A {
+  float b;
+  float c;
+  B bs;
+};
+
+// Use a pointer to member variable (A::*ptr)
+double* foo(A* ar, B A::*member_pointer) {
+  // CHECK: Final Type: {{.*}} = !DIBasicType(name: "double",
+  (ar->*member_pointer).x = static_cast<double*>(malloc(sizeof(double)));
+  return nullptr;
+}


### PR DESCRIPTION
- Check if operator (load) is really  inlined. Otherwise, may fail in case of fwd declared struct, see `gep/gep_pointer_to_member_fwd.cpp`
- Check inline operator does not return void
- Test for member to function pointer access (unsupported)