### PR TITLE
Disable TBAA for all cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        preset: [coverage]
+        llvm-version: [18, 19, 20]
+        os: [ubuntu-24.04]
+        use-tbaa: [true, false]
         include:
           - llvm-version: 13
             os: ubuntu-22.04
@@ -50,20 +54,6 @@ jobs:
           - llvm-version: 15
             os: ubuntu-22.04
             preset: coverage
-          - llvm-version: 18
-            os: ubuntu-24.04
-            preset: coverage
-          - llvm-version: 18
-            os: ubuntu-24.04
-            preset: coverage
-            use-tbaa: true
-          - llvm-version: 19
-            os: ubuntu-24.04
-            preset: coverage
-          - llvm-version: 19
-            os: ubuntu-24.04
-            preset: coverage
-            use-tbaa: true
 
     runs-on: ${{ matrix.os }}
 
@@ -71,10 +61,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: LLVM apt
-        if: ${{ matrix.llvm-version == 19 }}
+        if: ${{ matrix.llvm-version > 19 }}
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee /etc/apt/sources.list.d/llvm-19.list
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ matrix.llvm-version }} main" | sudo tee /etc/apt/sources.list.d/llvm-${{ matrix.llvm-version }}.list
 
       - name: Update apt
         run: sudo apt-get update
@@ -93,7 +83,7 @@ jobs:
           sudo ln -f -s /usr/bin/clang-${{ matrix.llvm-version }} /usr/bin/clang
           sudo ln -f -s /usr/bin/clang++-${{ matrix.llvm-version }} /usr/bin/clang++
           echo "LLVM_CMAKE_DIR=/usr/lib/llvm-${{ matrix.llvm-version }}/cmake" >> $GITHUB_ENV
-          echo "EXTERNAL_LIT=/usr/lib/llvm-${{ matrix.llvm-version }}/build/utils/lit/lit.py" >> $GITHUB_ENV
+          echo "EXTERNAL_LIT=/usr/lib/llvm-${{ matrix.llvm-version == 20 && 18 || matrix.llvm-version }}/build/utils/lit/lit.py" >> $GITHUB_ENV
           echo "USE_TBAA=${{ matrix.use-tbaa == true && 'ON' || 'OFF' }}" >> $GITHUB_ENV
 
       - name: Configure Dimeta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,17 @@ jobs:
           - llvm-version: 18
             os: ubuntu-24.04
             preset: coverage
+          - llvm-version: 18
+            os: ubuntu-24.04
+            preset: coverage
+            use-tbaa: true
           - llvm-version: 19
             os: ubuntu-24.04
             preset: coverage
+          - llvm-version: 19
+            os: ubuntu-24.04
+            preset: coverage
+            use-tbaa: true
 
     runs-on: ${{ matrix.os }}
 
@@ -86,9 +94,14 @@ jobs:
           sudo ln -f -s /usr/bin/clang++-${{ matrix.llvm-version }} /usr/bin/clang++
           echo "LLVM_CMAKE_DIR=/usr/lib/llvm-${{ matrix.llvm-version }}/cmake" >> $GITHUB_ENV
           echo "EXTERNAL_LIT=/usr/lib/llvm-${{ matrix.llvm-version }}/build/utils/lit/lit.py" >> $GITHUB_ENV
+          echo "USE_TBAA=${{ matrix.use-tbaa == true && 'ON' || 'OFF' }}" >> $GITHUB_ENV
 
       - name: Configure Dimeta
-        run: cmake -B build --preset ${{ matrix.preset }} -DLLVM_DIR=${LLVM_CMAKE_DIR} -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT}
+        run: |
+          cmake -B build --preset ${{ matrix.preset }} \
+            -DLLVM_DIR=${LLVM_CMAKE_DIR} \
+            -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT} \
+            -DDIMETA_USE_TBAA=${USE_TBAA}
 
       - name: Build Dimeta
         run: cmake --build build --parallel 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   format-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v5
@@ -22,7 +22,7 @@ jobs:
             -type f \
             -a \( -name "*.c" -o -name "*.cpp" -o -name "*.h" \) \
             -print0 \
-            | xargs -0 clang-format-14 -i
+            | xargs -0 clang-format-18 -i
 
       - name: Format check
         run: |
@@ -107,7 +107,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: build/coverage.info
-          flag-name: ${{ matrix.llvm-version }}-${{ matrix.os }}
+          flag-name: ${{ matrix.llvm-version }}-${{ matrix.use-tbaa }}-${{ matrix.os }}
           parallel: true
 
   finish-coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,21 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main" | sudo tee /etc/apt/sources.list.d/llvm-18.list
+
+      - name: Update apt
+        run: sudo apt-get update
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get remove clang-format-*
+          sudo apt-get install -t llvm-toolchain-noble-18 clang-format-18
+
       - name: Format source code
         run: |
-          find lib test \
+          find demo lib test \
             -type f \
             -a \( -name "*.c" -o -name "*.cpp" -o -name "*.h" \) \
             -print0 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Format source code
         run: |
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
+      - uses: actions/checkout@v5
+      - uses: codespell-project/actions-codespell@v2.1
 
   lit-suite:
     strategy:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: LLVM apt
         if: ${{ matrix.llvm-version > 19 }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,8 @@ include(dimetaToolchain)
 
 if(DIMETA_IS_TOP_LEVEL)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-  set(CMAKE_VERBOSE_MAKEFILE OFF)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 dimeta_target_format(
   format-dimeta-sources "Formats project source files"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ entry:
 
 ## 2. Building llvm-dimeta
 
-llvm-dimeta is tested with LLVM version 13, 14, 15, 18 and 19, and CMake version >= 3.20. Use CMake presets `develop` or `release` to build.
+llvm-dimeta is tested with LLVM version 13--15 and 18--20, and CMake version >= 3.20. Use CMake presets `develop` or `release` to build.
 
 ### 2.1 Build example
 

--- a/cmake/dimetaToolchain.cmake
+++ b/cmake/dimetaToolchain.cmake
@@ -25,6 +25,9 @@ string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}"
   DIMETA_IS_TOP_LEVEL
 )
 
+option(DIMETA_USE_TBAA "Use TBAA metadata if present." OFF)
+mark_as_advanced(DIMETA_USE_TBAA)
+
 option(DIMETA_PASS_PLUGIN "Compile LLVM pass plugin." OFF)
 mark_as_advanced(DIMETA_PASS_PLUGIN)
 

--- a/cmake/modules/dimeta-target-util.cmake
+++ b/cmake/modules/dimeta-target-util.cmake
@@ -20,8 +20,10 @@ function(dimeta_target_define_file_basename targetname)
 endfunction()
 
 function(dimeta_target_compile_opts targetname)
-  set_property(TARGET ${targetname} APPEND_STRING PROPERTY
-          COMPILE_FLAGS "-fno-exceptions -fno-rtti")
+  target_compile_features(${targetname} PUBLIC cxx_std_17)
+  set_target_properties(${targetname} PROPERTIES 
+          CXX_EXTENSIONS OFF
+          CXX_STANDARD_REQUIRED OFF)
 endfunction()
 
 function (dimeta_target_generate_file input output)

--- a/lib/type/CMakeLists.txt
+++ b/lib/type/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LIB_SOURCES
   Dimeta.h
   DimetaIO.h
   DimetaParse.h
-  TBAA.cpp
   DataflowAnalysis.cpp
   GEP.cpp
   SourceLocType.cpp
@@ -15,6 +14,10 @@ set(LIB_SOURCES
   DIRootType.cpp
   DITypeExtractor.cpp
 )
+
+if(DIMETA_USE_TBAA)
+  set(LIB_SOURCES ${LIB_SOURCES} TBAA.cpp)
+endif()
 
 add_library(dimeta_Types STATIC
   "${LIB_SOURCES}"
@@ -28,14 +31,14 @@ set_property(TARGET dimeta_Types PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(dimeta_Types SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
 
-target_compile_definitions(dimeta_Types PRIVATE $<$<BOOL:${DIMETA_USE_HEAPALLOCSITE}>:DIMETA_USE_HEAPALLOCSITE=1>)
-
 #target_link_libraries(dimeta_Types PRIVATE LLVMCore)
 
 target_compile_definitions(dimeta_Types
         PRIVATE
         LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR}
         DIMETA_LOG_LEVEL=${DIMETA_LOG_LEVEL}
+        $<$<BOOL:${DIMETA_USE_HEAPALLOCSITE}>:DIMETA_USE_HEAPALLOCSITE=1>
+        $<$<BOOL:${DIMETA_USE_TBAA}>:DIMETA_USE_TBAA=1>
         )
 
 dimeta_target_compile_opts(dimeta_Types)

--- a/lib/type/CMakeLists.txt
+++ b/lib/type/CMakeLists.txt
@@ -28,6 +28,9 @@ add_library(dimeta::Types ALIAS dimeta_Types)
 dimeta_target_define_file_basename(dimeta_Types)
 
 set_property(TARGET dimeta_Types PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET ${targetname} APPEND_STRING PROPERTY
+          COMPILE_FLAGS "-fno-exceptions -fno-rtti")
+dimeta_target_compile_opts(dimeta_Types)
 
 target_include_directories(dimeta_Types SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
 
@@ -41,8 +44,6 @@ target_compile_definitions(dimeta_Types
         $<$<BOOL:${DIMETA_USE_TBAA}>:DIMETA_USE_TBAA=1>
         )
 
-dimeta_target_compile_opts(dimeta_Types)
-
 target_include_directories(
   dimeta_Types
   PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/>
@@ -55,7 +56,6 @@ set_target_properties(
   OUTPUT_NAME "dimetaTypes"
   EXPORT_NAME "Types"
 )
-
 
 set(CONFIG_NAME dimetaTypes)
 set(TARGETS_EXPORT_NAME ${CONFIG_NAME}Targets)

--- a/lib/type/DIFinder.cpp
+++ b/lib/type/DIFinder.cpp
@@ -46,27 +46,44 @@ namespace dimeta::difinder {
 
 namespace compat {
 
+namespace impl {
+#if LLVM_VERSION_MAJOR > 16
+
+template <typename DbgVar>
+inline bool is_dbg_assign_impl(const DbgVar* dbg_var) {
+#if LLVM_VERSION_MAJOR < 19
+  return (dbg_var->getIntrinsicID() == llvm::Intrinsic::dbg_assign);
+#else
+  return (dbg_var->getType() == llvm::DbgVariableRecord::LocationType::Assign);
+#endif
+  return false;
+}
+
+template <typename DbgVar>
+inline auto get_assigns_impl(const DbgVar* dbg_var) {
+#if LLVM_VERSION_MAJOR < 19
+  return llvm::at::getAssignmentInsts(llvm::dyn_cast<llvm::DbgAssignIntrinsic>(dbg_var));
+#else
+  return llvm::at::getAssignmentInsts(llvm::dyn_cast<llvm::DbgVariableRecord>(dbg_var));
+#endif
+}
+
+#endif
+}  // namespace impl
+
 template <typename DbgVar>
 inline bool is_dbg_assign(const DbgVar* dbg_var) {
-  bool is_dbg_assign = false;
 #if LLVM_VERSION_MAJOR > 16
-#if LLVM_VERSION_MAJOR < 19
-  is_dbg_assign = (dbg_var->getIntrinsicID() == llvm::Intrinsic::dbg_assign);
+  return impl::is_dbg_assign_impl(dbg_var);
 #else
-  is_dbg_assign = (dbg_var->getType() == llvm::DbgVariableRecord::LocationType::Assign);
+  return false;
 #endif
-#endif
-  return is_dbg_assign;
 }
 
 template <typename DbgVar>
 std::optional<llvm::Value*> get_alloca_from_dbg_assign(const DbgVar* dbg_var) {
 #if LLVM_VERSION_MAJOR > 16
-#if LLVM_VERSION_MAJOR < 19
-  auto assigns = llvm::at::getAssignmentInsts(llvm::dyn_cast<llvm::DbgAssignIntrinsic>(dbg_var));
-#else
-  auto assigns  = llvm::at::getAssignmentInsts(llvm::dyn_cast<llvm::DbgVariableRecord>(dbg_var));
-#endif
+  const auto assigns = impl::get_assigns_impl(dbg_var);
   for (llvm::Value* assign : assigns) {
     if (auto* store = llvm::dyn_cast<llvm::StoreInst>(assign)) {
       return store->getPointerOperand();
@@ -80,11 +97,9 @@ template <typename DbgVar>
 const llvm::Value* get_alloca_for(const DbgVar* dbg_var) {
 #if LLVM_VERSION_MAJOR < 13
   return dbg_var->getVariableLocation();
-
 #elif LLVM_VERSION_MAJOR <= 16
   return dbg_var->getVariableLocationOp(0);
 #else
-
   if (is_dbg_assign(dbg_var)) {
     return get_alloca_from_dbg_assign(dbg_var).value_or(nullptr);
   }
@@ -94,11 +109,7 @@ const llvm::Value* get_alloca_for(const DbgVar* dbg_var) {
 
 template <typename DbgVar>
 llvm::DIExpression* get_expr_for(const DbgVar* dbg_var) {
-#if LLVM_VERSION_MAJOR < 13
   return dbg_var->getExpression();
-#else
-  return dbg_var->getExpression();
-#endif
 }
 
 }  // namespace compat
@@ -106,10 +117,9 @@ llvm::DIExpression* get_expr_for(const DbgVar* dbg_var) {
 #if LLVM_VERSION_MAJOR < 19
 
 std::optional<const llvm::DbgVariableIntrinsic*> find_intrinsic(const llvm::Instruction* ai) {
-  using namespace llvm;
   auto& func = *ai->getFunction();
   for (auto& inst : llvm::instructions(func)) {
-    if (auto* dbg = dyn_cast<DbgVariableIntrinsic>(&inst)) {
+    if (auto* dbg = llvm::dyn_cast<llvm::DbgVariableIntrinsic>(&inst)) {
       if (compat::get_alloca_for(dbg) == ai) {
         return dbg;
       }

--- a/lib/type/DIFinder.cpp
+++ b/lib/type/DIFinder.cpp
@@ -35,6 +35,7 @@
 
 #include <cassert>
 #include <iterator>
+#include <llvm/IR/DebugInfo.h>
 #include <optional>
 
 namespace llvm {
@@ -44,11 +45,49 @@ class DbgVariableIntrinsic;
 namespace dimeta::difinder {
 
 namespace compat {
+
 template <typename DbgVar>
-llvm::Value* get_alloca_for(const DbgVar* dbg_var) {
+inline bool is_dbg_assign(const DbgVar* dbg_var) {
+  bool is_dbg_assign = false;
+#if LLVM_VERSION_MAJOR > 16
+#if LLVM_VERSION_MAJOR < 19
+  is_dbg_assign = (dbg_var->getIntrinsicID() == llvm::Intrinsic::dbg_assign);
+#else
+  is_dbg_assign = (dbg_var->getType() == llvm::DbgVariableRecord::LocationType::Assign);
+#endif
+#endif
+  return is_dbg_assign;
+}
+
+template <typename DbgVar>
+std::optional<llvm::Value*> get_alloca_from_dbg_assign(const DbgVar* dbg_var) {
+#if LLVM_VERSION_MAJOR > 16
+#if LLVM_VERSION_MAJOR < 19
+  auto assigns = llvm::at::getAssignmentInsts(llvm::dyn_cast<llvm::DbgAssignIntrinsic>(dbg_var));
+#else
+  auto assigns  = llvm::at::getAssignmentInsts(llvm::dyn_cast<llvm::DbgVariableRecord>(dbg_var));
+#endif
+  for (llvm::Value* assign : assigns) {
+    if (auto* store = llvm::dyn_cast<llvm::StoreInst>(assign)) {
+      return store->getPointerOperand();
+    }
+  }
+#endif
+  return {};
+}
+
+template <typename DbgVar>
+const llvm::Value* get_alloca_for(const DbgVar* dbg_var) {
 #if LLVM_VERSION_MAJOR < 13
   return dbg_var->getVariableLocation();
+
+#elif LLVM_VERSION_MAJOR <= 16
+  return dbg_var->getVariableLocationOp(0);
 #else
+
+  if (is_dbg_assign(dbg_var)) {
+    return get_alloca_from_dbg_assign(dbg_var).value_or(nullptr);
+  }
   return dbg_var->getVariableLocationOp(0);
 #endif
 }
@@ -61,6 +100,7 @@ llvm::DIExpression* get_expr_for(const DbgVar* dbg_var) {
   return dbg_var->getExpression();
 #endif
 }
+
 }  // namespace compat
 
 #if LLVM_VERSION_MAJOR < 19

--- a/lib/type/DITypeExtractor.cpp
+++ b/lib/type/DITypeExtractor.cpp
@@ -298,9 +298,13 @@ std::optional<llvm::DIType*> reset_store_related_basic(const dataflow::ValuePath
       auto result = di::util::resolve_byte_offset_to_member_of(desugared_composite.value(), 0);
       if (result) {
 #if DIMETA_USE_TBAA == 1
-        if (result->member && result->member.value()->getName().starts_with("_vptr")) {
+        if (result->member) {
+          const auto member_name = result->member.value()->getName();
+          const bool is_vptr     = dimeta::util::starts_with_any_of(member_name, "_vptr");
           // Let this be handled by TBAA is available, see test 10_lulesh_ad_tbaa_static_member.ll
-          return type;
+          if (is_vptr) {
+            return type;
+          }
         }
 #endif
         LOG_DEBUG("Return type of store " << log::ditype_str(result->type_of_member.value_or(nullptr)))

--- a/lib/type/DIUtil.cpp
+++ b/lib/type/DIUtil.cpp
@@ -226,4 +226,9 @@ bool is_array_member(const llvm::DINode& elem) {
          llvm::dyn_cast<llvm::DIDerivedType>(&elem)->getBaseType()->getTag() == llvm::dwarf::DW_TAG_array_type;
 }
 
+bool is_array(const llvm::DINode& elem) {
+  auto comp = llvm::dyn_cast<llvm::DICompositeType>(&elem);
+  return (comp != nullptr) && comp->getTag() == llvm::dwarf::DW_TAG_array_type;
+}
+
 }  // namespace dimeta::di::util

--- a/lib/type/DIUtil.h
+++ b/lib/type/DIUtil.h
@@ -10,6 +10,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 
+#include <llvm/IR/Instruction.h>
 #include <optional>
 
 namespace llvm {
@@ -39,6 +40,9 @@ bool is_non_static_member(const llvm::DINode& elem);
 bool is_member(const llvm::DINode& elem);
 size_t get_num_composite_members(const llvm::DICompositeType& composite);
 llvm::SmallVector<llvm::DIDerivedType*, 4> get_composite_members(const llvm::DICompositeType& composite);
+std::optional<llvm::DICompositeType*> desugar(llvm::DIType& qualified_composite, int pointer_level = 1);
+// bool has_tbaa(const llvm::Instruction&);
+bool is_array_member(const llvm::DINode& elem);
 
 }  // namespace dimeta::di::util
 

--- a/lib/type/DIUtil.h
+++ b/lib/type/DIUtil.h
@@ -43,6 +43,7 @@ llvm::SmallVector<llvm::DIDerivedType*, 4> get_composite_members(const llvm::DIC
 std::optional<llvm::DICompositeType*> desugar(llvm::DIType& qualified_composite, int pointer_level = 1);
 // bool has_tbaa(const llvm::Instruction&);
 bool is_array_member(const llvm::DINode& elem);
+bool is_array(const llvm::DINode& elem);
 
 }  // namespace dimeta::di::util
 

--- a/lib/type/Dimeta.cpp
+++ b/lib/type/Dimeta.cpp
@@ -65,9 +65,8 @@ llvm::SmallVector<llvm::DIType*, 4> collect_types(const llvm::CallBase* call,
                                                   llvm::ArrayRef<dataflow::ValuePath> paths_to_type) {
   using namespace llvm;
   SmallVector<llvm::DIType*, 4> di_types;
-  llvm::transform(paths_to_type, dimeta::util::optional_back_inserter(di_types), [&](const auto& path) {
-    return type::find_type(dataflow::CallValuePath{call, path});
-  });
+  llvm::transform(paths_to_type, dimeta::util::optional_back_inserter(di_types),
+                  [&](const auto& path) { return type::find_type(dataflow::CallValuePath{call, path}); });
   return di_types;
 }
 

--- a/lib/type/GEP.h
+++ b/lib/type/GEP.h
@@ -21,6 +21,7 @@ namespace dimeta::gep {
 struct GepIndexToType {
   std::optional<llvm::DIType*> type;
   std::optional<llvm::DIDerivedType*> member{};
+  bool use_type{false};
 };
 
 GepIndexToType extract_gep_dereferenced_type(llvm::DIType* root, const llvm::GEPOperator& inst);

--- a/lib/type/Util.h
+++ b/lib/type/Util.h
@@ -9,9 +9,19 @@
 #define DIMETA_UTIL_H
 
 #include <functional>
+#include <llvm/ADT/StringRef.h>
 #include <optional>
 
 namespace dimeta::util {
+
+template <typename... StringTy>
+inline bool starts_with_any_of(llvm::StringRef lhs, StringTy... rhs) {
+#if LLVM_VERSION_MAJOR > 15
+  return !lhs.empty() && ((lhs.starts_with(rhs)) || ...);
+#else
+  return !lhs.empty() && ((lhs.startswith(rhs)) || ...);
+#endif
+}
 
 template <typename Fn>
 class ScopeExit {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ function(configure_dimeta_lit_site_cfg input output)
   set(DIMETA_SCRIPT_DIR ${CMAKE_BINARY_DIR}/scripts)
 
   pythonize_bool(DIMETA_USE_HEAPALLOCSITE DIMETA_HEAPALLOCSITE)
+  pythonize_bool(DIMETA_USE_TBAA DIMETA_TBAA)
 
   if(${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL "13")
     #set(DIMETA_OPT_ARGS "-enable-new-pm=0")

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -48,6 +48,9 @@ if config.heapallocsite:
 else:
     config.available_features.add('heapmanual')
 
+if config.tbaa:
+    config.available_features.add('tbaa')
+
 if config.llvm_version < 14:
   config.available_features.add('legacyllvm')
 

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -19,6 +19,7 @@ config.dimeta_script_dir = "@DIMETA_SCRIPT_DIR@"
 config.dimeta_test_pass = "$<TARGET_FILE_NAME:dimeta::TestPass>"
 
 config.heapallocsite = @DIMETA_HEAPALLOCSITE@
+config.tbaa = @DIMETA_TBAA@
 
 config.llvm_version = @LLVM_VERSION_MAJOR@
 

--- a/test/pass/c/global_heap.c
+++ b/test/pass/c/global_heap.c
@@ -1,0 +1,14 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+#include <stdlib.h>
+
+double* a;
+
+void foo(int argc) {
+  a = (double*)malloc(sizeof(double) * argc);
+}
+// malloc:
+// CHECK: Final Type: {{.*}} = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
+// CHECK: Pointer level: 1
+// CHECK: Location: "{{.*}}":"foo":9

--- a/test/pass/c/heap_assign_array_milc_mock.c
+++ b/test/pass/c/heap_assign_array_milc_mock.c
@@ -1,0 +1,39 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier 2>&1 | %filecheck %s
+
+#include "stdlib.h"
+typedef struct {
+  double c[3];
+} su3_vector;
+
+void take(void*);
+void eo_fermion_force(int sites_on_node) {
+  int mu, nu, rho, sig;
+  su3_vector* tempvec[8];
+  // su3_vector* temp_x;
+
+  /* Allocate temporary vectors */
+  for (mu = 0; mu < 8; mu++)
+    tempvec[mu] = (su3_vector*)malloc(sites_on_node * sizeof(su3_vector));
+
+  take((void*)tempvec[0]);
+}
+
+// CHECK:  Line:            17
+// CHECK-NEXT:Builtin:         false
+// CHECK-NEXT:Type:
+// CHECK-NEXT:  Compound:
+// CHECK-NEXT:    Name:            ''
+// CHECK-NEXT:    Type:            struct
+// CHECK-NEXT:    Extent:          24
+// CHECK-NEXT:    Sizes:           [ 24 ]
+// CHECK-NEXT:    Offsets:         [ 0 ]
+// CHECK-NEXT:    Members:
+// CHECK-NEXT:      - Name:            c
+// CHECK-NEXT:        Builtin:         true
+// CHECK-NEXT:        Type:
+// CHECK-NEXT:          Fundamental:     { Name: double, Extent: 8, Encoding: float }
+// CHECK-NEXT:          Array:           [ 3 ]
+// CHECK-NEXT:          Qualifiers:      [ array ]
+// CHECK-NEXT:  Qualifiers:      [ ptr ]
+// CHECK-NEXT:  Typedef:         su3_vector

--- a/test/pass/c/heap_loop_source_loc.c
+++ b/test/pass/c/heap_loop_source_loc.c
@@ -1,4 +1,5 @@
 // RUN: %c-to-llvm %s | %apply-verifier |& %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O2 | %apply-verifier |& %filecheck %s
 
 #include <stdlib.h>
 
@@ -11,4 +12,4 @@ void foo(int** entries, int n) {
 // CHECK: Final Type: {{.*}} = !DIBasicType(name: "int",
 // CHECK-NEXT: Pointer level: 1 (T*)
 
-// CHECK: Location: "{{.*}}heap_loop_source_loc.c":"foo":7
+// CHECK: Location: "{{.*}}heap_loop_source_loc.c":"foo":8

--- a/test/pass/cuda/heap_template_no_assign.ll
+++ b/test/pass/cuda/heap_template_no_assign.ll
@@ -1,8 +1,8 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; REQUIRES: llvm-18 || llvm-19
 
-; CHECK:   Function:        'cudaMalloc<float>'
-; CHECK-NEXT:   Line:            684
+;    Function:        'cudaMalloc<float>'
+; CHECK:   Line:            684
 ; CHECK-NEXT: Builtin:         true
 ; CHECK-NEXT: Type:
 ; CHECK-NEXT:   Fundamental:     { Name: float, Extent: 4, Encoding: float }

--- a/test/pass/inheritance/stack_class_multi_inheritance_virtual.cpp
+++ b/test/pass/inheritance/stack_class_multi_inheritance_virtual.cpp
@@ -4,7 +4,7 @@ class Base {
  public:
   double x;
 
-  virtual void foo(){};
+  virtual void foo() {};
 };
 
 class X {

--- a/test/pass/ir/02_mpicxx.ll
+++ b/test/pass/ir/02_mpicxx.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
 
 ; CHECK: SourceLoc:
 ; CHECK-NEXT:   File:            '/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/datatype_inln.h'

--- a/test/pass/ir/03_lulesh_ad.ll
+++ b/test/pass/ir/03_lulesh_ad.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/04_lulesh_ad_gep.ll
+++ b/test/pass/ir/04_lulesh_ad_gep.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/05_vector_copy_return.ll
+++ b/test/pass/ir/05_vector_copy_return.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/06_amg_llvm_19.ll
+++ b/test/pass/ir/06_amg_llvm_19.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-19
+; REQUIRES: llvm-19 || llvm-20
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/07_tbaa_offset_16.ll
+++ b/test/pass/ir/07_tbaa_offset_16.ll
@@ -1,8 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-19
+; REQUIRES: llvm-19 && tbaa
 ; CHECK-NOT: Assertion
-
-; XFAIL: *
 
 ; CHECK:   Line:            32
 ; CHECK-NEXT: Builtin:         true

--- a/test/pass/ir/07_tbaa_offset_16.ll
+++ b/test/pass/ir/07_tbaa_offset_16.ll
@@ -2,6 +2,8 @@
 ; REQUIRES: llvm-19
 ; CHECK-NOT: Assertion
 
+; XFAIL: *
+
 ; CHECK:   Line:            32
 ; CHECK-NEXT: Builtin:         true
 ; CHECK-NEXT: Type:

--- a/test/pass/ir/07_tbaa_offset_16.ll
+++ b/test/pass/ir/07_tbaa_offset_16.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-19 && tbaa
+; REQUIRES: (llvm-19 || llvm-20) && tbaa
 ; CHECK-NOT: Assertion
 
 ; CHECK:   Line:            32

--- a/test/pass/ir/08_tbaa_offset_8.ll
+++ b/test/pass/ir/08_tbaa_offset_8.ll
@@ -1,8 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-19
+; REQUIRES: llvm-19 && tbaa
 ; CHECK-NOT: Assertion
-
-; XFAIL: *
 
 ; CHECK:   Line:            32
 ; CHECK-NEXT: Builtin:         true

--- a/test/pass/ir/08_tbaa_offset_8.ll
+++ b/test/pass/ir/08_tbaa_offset_8.ll
@@ -2,6 +2,8 @@
 ; REQUIRES: llvm-19
 ; CHECK-NOT: Assertion
 
+; XFAIL: *
+
 ; CHECK:   Line:            32
 ; CHECK-NEXT: Builtin:         true
 ; CHECK-NEXT: Type:

--- a/test/pass/ir/08_tbaa_offset_8.ll
+++ b/test/pass/ir/08_tbaa_offset_8.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-19 && tbaa
+; REQUIRES: (llvm-19 || llvm-20) && tbaa
 ; CHECK-NOT: Assertion
 
 ; CHECK:   Line:            32

--- a/test/pass/ir/09_lulesh_ad_gep_static_member.ll
+++ b/test/pass/ir/09_lulesh_ad_gep_static_member.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44
 ; CHECK: Extracted Type: !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)

--- a/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
+++ b/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
@@ -1,6 +1,8 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; REQUIRES: llvm-18 || llvm-19
 
+; XFAIL: *
+
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44
 ; CHECK: Extracted Type: !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
 ; CHECK: Final Type: !31 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)

--- a/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
+++ b/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
@@ -1,7 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: (llvm-18 || llvm-19) && tbaa
 
-; XFAIL: *
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44
 ; CHECK: Extracted Type: !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)

--- a/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
+++ b/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-18 || llvm-19) && tbaa
+; REQUIRES: (llvm-18 || llvm-19 || llvm-20) && tbaa
 
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44

--- a/test/pass/ir/11_unroll_quark_milc.ll
+++ b/test/pass/ir/11_unroll_quark_milc.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
 
 ; CHECK-COUNT-7: Location: "{{.*}}quark_stuff.c":"eo_fermion_force_3f":1293
 

--- a/test/pass/ir/12_dse_debug_assign.ll
+++ b/test/pass/ir/12_dse_debug_assign.ll
@@ -1,0 +1,56 @@
+; RUN: %apply-verifier %s |& %filecheck %s
+; REQUIRES: llvm-18 || llvm-19 || llvm-20
+
+; CHECK: Final Type Stack: !{{.*}} = !DIBasicType(name: "int",
+
+; Note: Taken from the LLVM test suite
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define dso_local void @fun() local_unnamed_addr !dbg !7 {
+entry:
+  %local = alloca i32, align 4
+  call void @llvm.dbg.assign(metadata i32 5, metadata !11, metadata !DIExpression(), metadata !30, metadata ptr %local, metadata !DIExpression()), !dbg !16
+  store i32 6, ptr %local, align 4, !dbg !23, !DIAssignID !31
+  call void @llvm.dbg.assign(metadata i32 6, metadata !11, metadata !DIExpression(), metadata !31, metadata ptr %local, metadata !DIExpression()), !dbg !16
+  call void @esc(ptr nonnull %local), !dbg !24
+  ret void, !dbg !25
+}
+
+declare void @llvm.dbg.assign(metadata, metadata, metadata, metadata, metadata, metadata)
+
+declare !dbg !26 dso_local void @esc(ptr) local_unnamed_addr
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !1000}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 12.0.0", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.c", directory: "/")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang version 12.0.0"}
+!7 = distinct !DISubprogram(name: "fun", scope: !1, file: !1, line: 2, type: !8, scopeLine: 2, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !10)
+!8 = !DISubroutineType(types: !9)
+!9 = !{null}
+!10 = !{!11}
+!11 = !DILocalVariable(name: "local", scope: !7, file: !1, line: 3, type: !12)
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !12)
+!15 = !DILocation(line: 3, column: 3, scope: !7)
+!16 = !DILocation(line: 0, scope: !7)
+!17 = !DILocation(line: 4, column: 3, scope: !7)
+!18 = !DILocation(line: 4, column: 16, scope: !7)
+!23 = !DILocation(line: 5, column: 9, scope: !7)
+!24 = !DILocation(line: 6, column: 3, scope: !7)
+!25 = !DILocation(line: 7, column: 1, scope: !7)
+!26 = !DISubprogram(name: "esc", scope: !1, file: !1, line: 1, type: !27, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, retainedNodes: !2)
+!27 = !DISubroutineType(types: !28)
+!28 = !{null, !29}
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !12, size: 64)
+!30 = distinct !DIAssignID()
+!31 = distinct !DIAssignID()
+
+!1000 = !{i32 7, !"debug-info-assignment-tracking", i1 true}

--- a/test/verifier/CMakeLists.txt
+++ b/test/verifier/CMakeLists.txt
@@ -14,6 +14,8 @@ set_target_properties(
         EXPORT_NAME "TestPass"
 )
 
+dimeta_target_compile_opts(dimeta_TestPass)
+
 add_library(dimeta::TestPass ALIAS dimeta_TestPass)
 
 target_include_directories(dimeta_TestPass


### PR DESCRIPTION
- TBAA metadata usage to resolve heap allocated types  is optional now
- Update to support LLVM 20