### PR TITLE
LLVM 22 support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,7 +69,7 @@ CheckOptions:
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
   - { key: readability-identifier-naming.ClassMemberSuffix,      value: _ }
-  - { key: readability-identifier-naming.PriateMemberSuffix,    value: _ }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _ }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _ }
   - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
   - { key: readability-identifier-naming.EnumConstantPrefix,       value: k }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: [coverage]
-        llvm-version: [18, 19, 20, 21]
+        llvm-version: [18, 19, 20, 21, 22]
         os: [ubuntu-24.04]
         use-tbaa: [true, false]
         with-flang: [false]
         include:
           - llvm-version: 13
             os: ubuntu-22.04
-            preset: coverage
           - llvm-version: 14
             os: ubuntu-22.04
-            preset: coverage
           - llvm-version: 15
             os: ubuntu-22.04
-            preset: coverage
           - llvm-version: 21
             os: ubuntu-24.04
-            preset: coverage
             use-tbaa: true
             with-flang: true
           - llvm-version: 21
             os: ubuntu-24.04
-            preset: coverage
+            use-tbaa: false
+            with-flang: true
+          - llvm-version: 22
+            os: ubuntu-24.04
+            use-tbaa: true
+            with-flang: true
+          - llvm-version: 22
+            os: ubuntu-24.04
             use-tbaa: false
             with-flang: true
 
@@ -119,7 +121,7 @@ jobs:
 
       - name: Configure Dimeta
         run: |
-          cmake -B build --preset ${{ matrix.preset }} \
+          cmake -B build --preset coverage \
             -DLLVM_DIR=${LLVM_CMAKE_DIR} \
             -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT} \
             -DDIMETA_USE_TBAA=${USE_TBAA} \

--- a/lib/type/DIUtil.cpp
+++ b/lib/type/DIUtil.cpp
@@ -105,7 +105,7 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
   bool visitCompositeType(const llvm::DICompositeType* composite) const {
     LOG_DEBUG("visitCompositeType: " << log::ditype_str(composite) << ": " << composite->getName()
                                      << " index: " << byte_index_ << " offset base: " << this->offset_base_);
-    return true;
+    return !terminate;
   }
 
   bool visitDerivedType(const llvm::DIDerivedType* derived_ty) {
@@ -133,6 +133,7 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
       if (is_pointer_like(*member_base_type) || is_array(*member_base_type)) {
         LOG_DEBUG("Terminating recursion, found pointer-like " << is_pointer_like(*member_base_type)
                                                                << " or array-like " << is_array(*member_base_type))
+        terminate = true;
         return false;  // if offset matches, and its a pointer-like, we do not need to recurse.
       }
 
@@ -150,6 +151,7 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
   size_t byte_index_;
   size_t offset_base_{};
   std::optional<StructMember> outermost_candidate_{};
+  bool terminate{false};
 };
 
 std::optional<StructMember> resolve_byte_offset_to_member_of(const llvm::DICompositeType* composite, size_t offset) {

--- a/test/pass/c/stack_struct_bitint.c
+++ b/test/pass/c/stack_struct_bitint.c
@@ -21,12 +21,12 @@ void foo() {
 // CHECK-NEXT:   - Name:            bitint8_var
 // CHECK-NEXT:     Builtin:         true
 // CHECK-NEXT:     Type:
-// CHECK-NEXT:       Fundamental:     { Name: _BitInt, Extent: 1, Encoding: signed_int }
+// CHECK-NEXT:       Fundamental:     { Name: {{[']?}}_BitInt{{.*[']?}}, Extent: 1, Encoding: signed_int }
 // CHECK-NEXT:   - Name:            bitint16_var
 // CHECK-NEXT:     Builtin:         true
 // CHECK-NEXT:     Type:
-// CHECK-NEXT:       Fundamental:     { Name: _BitInt, Extent: 2, Encoding: signed_int }
+// CHECK-NEXT:       Fundamental:     { Name: {{[']?}}_BitInt{{.*[']?}}, Extent: 2, Encoding: signed_int }
 // CHECK-NEXT:   - Name:            bitint32_var
 // CHECK-NEXT:     Builtin:         true
 // CHECK-NEXT:     Type:
-// CHECK-NEXT:       Fundamental:     { Name: _BitInt, Extent: 4, Encoding: signed_int }
+// CHECK-NEXT:       Fundamental:     { Name: {{[']?}}_BitInt{{.*[']?}}, Extent: 4, Encoding: signed_int }

--- a/test/pass/cuda/heap_template.ll
+++ b/test/pass/cuda/heap_template.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK:   Function:        'cudaMalloc<float>'
 ; CHECK-NEXT:   Line:            77

--- a/test/pass/cuda/heap_template_no_assign.ll
+++ b/test/pass/cuda/heap_template_no_assign.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ;    Function:        'cudaMalloc<float>'
 ; CHECK:   Line:            684

--- a/test/pass/fortran/02_heap_double.f90
+++ b/test/pass/fortran/02_heap_double.f90
@@ -17,4 +17,4 @@ END FUNCTION foo
 ! CHECK:  Line:            11
 ! CHECK-NEXT: Builtin:         true
 ! CHECK-NEXT: Type:
-! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }

--- a/test/pass/fortran/03_heap_mold.f90
+++ b/test/pass/fortran/03_heap_mold.f90
@@ -12,6 +12,6 @@ end subroutine
 ! CHECK:  Line:            9
 ! CHECK-NEXT: Builtin:         true
 ! CHECK-NEXT: Type:
-! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK-NEXT: Array:           [ 102 ]
 ! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/04_heap_mold_dim2.f90
+++ b/test/pass/fortran/04_heap_mold_dim2.f90
@@ -11,6 +11,6 @@ end subroutine
 ! CHECK:  Line:            8
 ! CHECK-NEXT: Builtin:         true
 ! CHECK-NEXT: Type:
-! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK-NEXT: Array:           [ 102, 10 ]
 ! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/16_nested_allocate.f90
+++ b/test/pass/fortran/16_nested_allocate.f90
@@ -1,4 +1,4 @@
-! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %apply-verifier | %filecheck %s
 ! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
 
 ! REQUIRES: hasflang
@@ -75,5 +75,5 @@ END MODULE test_mod
 ! CHECK-NEXT:     Sizes:           [ 88, 4, 4, 4, 4, 4, 4, 16, 8 ]
 
 ! CHECK: Line:            59
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/17_complex_nested_allocate.f90
+++ b/test/pass/fortran/17_complex_nested_allocate.f90
@@ -54,29 +54,29 @@ CONTAINS
 END MODULE test_mod
 
 ! CHECK: Line:            29
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            35
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            41
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            47
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            48
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            49
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            50
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/18_full_nested_allocate.f90
+++ b/test/pass/fortran/18_full_nested_allocate.f90
@@ -94,17 +94,17 @@ END MODULE test_mod
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            75
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            76
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            77
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            78
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]

--- a/test/pass/ir/02_mpicxx.ll
+++ b/test/pass/ir/02_mpicxx.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK: SourceLoc:
 ; CHECK-NEXT:   File:            '/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/datatype_inln.h'

--- a/test/pass/ir/03_lulesh_ad.ll
+++ b/test/pass/ir/03_lulesh_ad.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/04_lulesh_ad_gep.ll
+++ b/test/pass/ir/04_lulesh_ad_gep.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/05_vector_copy_return.ll
+++ b/test/pass/ir/05_vector_copy_return.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/06_amg_llvm_19.ll
+++ b/test/pass/ir/06_amg_llvm_19.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-19 || llvm-20
+; REQUIRES: llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/07_tbaa_offset_16.ll
+++ b/test/pass/ir/07_tbaa_offset_16.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-19 || llvm-20) && tbaa
+; REQUIRES: (llvm-19 || llvm-20 || llvm-21 || llvm-22) && tbaa
 ; CHECK-NOT: Assertion
 
 ; CHECK:   Line:            32

--- a/test/pass/ir/08_tbaa_offset_8.ll
+++ b/test/pass/ir/08_tbaa_offset_8.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-19 || llvm-20) && tbaa
+; REQUIRES: (llvm-19 || llvm-20 || llvm-21 || llvm-22) && tbaa
 ; CHECK-NOT: Assertion
 
 ; CHECK:   Line:            32

--- a/test/pass/ir/09_lulesh_ad_gep_static_member.ll
+++ b/test/pass/ir/09_lulesh_ad_gep_static_member.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44
 ; CHECK: Extracted Type: !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)

--- a/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
+++ b/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-18 || llvm-19 || llvm-20) && tbaa
+; REQUIRES: (llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22) && tbaa
 
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44

--- a/test/pass/ir/11_unroll_quark_milc.ll
+++ b/test/pass/ir/11_unroll_quark_milc.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK-COUNT-7: Location: "{{.*}}quark_stuff.c":"eo_fermion_force_3f":1293
 

--- a/test/pass/ir/12_dse_debug_assign.ll
+++ b/test/pass/ir/12_dse_debug_assign.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK: Final Type Stack: !{{.*}} = !DIBasicType(name: "int",
 

--- a/test/verifier/TestPass.cpp
+++ b/test/verifier/TestPass.cpp
@@ -28,7 +28,11 @@
 #include "llvm/IR/Value.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_MAJOR < 22
 #include "llvm/Passes/PassPlugin.h"
+#else
+#include "llvm/Plugins/PassPlugin.h"
+#endif
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"


### PR DESCRIPTION
- Bug: DIUtil::DestructureComposite was not correctly terminating when a fitting member was found. TODO, look at DINodeVisitor to fix termination. Potentially this includes `invoke_if` code logic.