### PR TITLE
Release 0.5

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,7 +54,6 @@ Checks: >
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,
   -performance-move-const-arg,
-  -readability-braces-around-statements,
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-declaration,
@@ -70,7 +69,7 @@ CheckOptions:
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
   - { key: readability-identifier-naming.ClassMemberSuffix,      value: _ }
-  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _ }
+  - { key: readability-identifier-naming.PriateMemberSuffix,    value: _ }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _ }
   - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
   - { key: readability-identifier-naming.EnumConstantPrefix,       value: k }
@@ -84,3 +83,4 @@ CheckOptions:
   - { key: readability-identifier-naming.StaticConstantPrefix,     value: k }
   - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1 }
   - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1 }
+  - { key: readability-braces-around-statements, value: 1 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,7 +69,7 @@ CheckOptions:
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
   - { key: readability-identifier-naming.ClassMemberSuffix,      value: _ }
-  - { key: readability-identifier-naming.PriateMemberSuffix,    value: _ }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _ }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _ }
   - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
   - { key: readability-identifier-naming.EnumConstantPrefix,       value: k }

--- a/.codespellrc
+++ b/.codespellrc
@@ -5,4 +5,4 @@ check-hidden =
 skip = */.git,*/build*,*/.codespellrc,*/install
 quiet-level = 2
 ignore-regex = ^#include <(?:stdio)\.h>$|DEPENDEES|\\endcode
-ignore-words-list = uint,iff
+ignore-words-list = uint,iff,INOUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: [coverage]
-        llvm-version: [18, 19, 20, 21]
+        llvm-version: [18, 19, 20, 21, 22]
         os: [ubuntu-24.04]
         use-tbaa: [true, false]
         with-flang: [false]
         include:
           - llvm-version: 13
             os: ubuntu-22.04
-            preset: coverage
           - llvm-version: 14
             os: ubuntu-22.04
-            preset: coverage
           - llvm-version: 15
             os: ubuntu-22.04
-            preset: coverage
           - llvm-version: 21
             os: ubuntu-24.04
-            preset: coverage
             use-tbaa: true
             with-flang: true
           - llvm-version: 21
             os: ubuntu-24.04
-            preset: coverage
+            use-tbaa: false
+            with-flang: true
+          - llvm-version: 22
+            os: ubuntu-24.04
+            use-tbaa: true
+            with-flang: true
+          - llvm-version: 22
+            os: ubuntu-24.04
             use-tbaa: false
             with-flang: true
 
@@ -119,7 +121,7 @@ jobs:
 
       - name: Configure Dimeta
         run: |
-          cmake -B build --preset ${{ matrix.preset }} \
+          cmake -B build --preset coverage \
             -DLLVM_DIR=${LLVM_CMAKE_DIR} \
             -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT} \
             -DDIMETA_USE_TBAA=${USE_TBAA} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         llvm-version: [18, 19, 20, 21]
         os: [ubuntu-24.04]
         use-tbaa: [true, false]
+        with-flang: [false]
         include:
           - llvm-version: 13
             os: ubuntu-22.04
@@ -66,6 +67,16 @@ jobs:
           - llvm-version: 15
             os: ubuntu-22.04
             preset: coverage
+          - llvm-version: 21
+            os: ubuntu-24.04
+            preset: coverage
+            use-tbaa: true
+            with-flang: true
+          - llvm-version: 21
+            os: ubuntu-24.04
+            preset: coverage
+            use-tbaa: false
+            with-flang: true
 
     runs-on: ${{ matrix.os }}
 
@@ -87,6 +98,10 @@ jobs:
       - name: Install Clang
         run: sudo apt-get install clang-${{ matrix.llvm-version }} clang-tidy-${{ matrix.llvm-version }}
 
+      - name: Install Flang
+        if: matrix.with-flang == true
+        run: sudo apt-get install flang-${{ matrix.llvm-version }} libflang-${{ matrix.llvm-version }}-dev
+
       - name: Install lcov
         run: sudo apt-get install lcov
 
@@ -94,16 +109,21 @@ jobs:
         run: |
           sudo ln -f -s /usr/bin/clang-${{ matrix.llvm-version }} /usr/bin/clang
           sudo ln -f -s /usr/bin/clang++-${{ matrix.llvm-version }} /usr/bin/clang++
+          if [ "${{ matrix.with-flang }}" = "true" ]; then
+            sudo ln -f -s /usr/bin/flang-${{ matrix.llvm-version }} /usr/bin/flang
+          fi
           echo "LLVM_CMAKE_DIR=/usr/lib/llvm-${{ matrix.llvm-version }}/cmake" >> $GITHUB_ENV
           echo "EXTERNAL_LIT=/usr/lib/llvm-${{ matrix.llvm-version >= 20 && 18 || matrix.llvm-version }}/build/utils/lit/lit.py" >> $GITHUB_ENV
           echo "USE_TBAA=${{ matrix.use-tbaa == true && 'ON' || 'OFF' }}" >> $GITHUB_ENV
+          echo "WITH_FLANG=${{ matrix.with-flang == true && 'ON' || 'OFF' }}" >> $GITHUB_ENV
 
       - name: Configure Dimeta
         run: |
           cmake -B build --preset ${{ matrix.preset }} \
             -DLLVM_DIR=${LLVM_CMAKE_DIR} \
             -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT} \
-            -DDIMETA_USE_TBAA=${USE_TBAA}
+            -DDIMETA_USE_TBAA=${USE_TBAA} \
+            -DDIMETA_ENABLE_FLANG=${WITH_FLANG}
 
       - name: Build Dimeta
         run: cmake --build build --parallel 2
@@ -119,7 +139,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: build/coverage.info
-          flag-name: ${{ matrix.llvm-version }}-${{ matrix.use-tbaa }}-${{ matrix.os }}
+          flag-name: ${{ matrix.llvm-version }}-${{ matrix.use-tbaa }}-${{ matrix.os }}-${{ matrix.with-flang }}
           parallel: true
 
   finish-coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(dimetaToolchain)
 
 if(DIMETA_IS_TOP_LEVEL)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-  set(CMAKE_VERBOSE_MAKEFILE ON)
+  set(CMAKE_VERBOSE_MAKEFILE OFF)
 endif()
 
 dimeta_target_format(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(dimeta
-  VERSION 0.4.0
+  VERSION 0.5.0
   HOMEPAGE_URL https://github.com/ahueck/llvm-dimeta
   LANGUAGES C CXX
 )

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ entry:
 
 ## 2. Building llvm-dimeta
 
-llvm-dimeta is tested with LLVM version 13-15 and 18-21, and CMake version >= 3.20. Use CMake presets `develop` or `release` to build.
+llvm-dimeta is tested with LLVM version 13-15 and 18-22, and CMake version >= 3.20. Use CMake presets `develop` or `release` to build.
 
 ### 2.1 Build example
 
@@ -147,7 +147,7 @@ $> cmake --build build --target install --parallel
 | `DIMETA_TEST_CONFIG`       |  `OFF`  | Enable test config, see Section [2.3](#23-testing) (sets log level etc.) |
 | `DIMETA_LOG_LEVEL`         |   `1`   | Granularity of pass logger. 3 is most verbose, 0 is least                |
 | `DIMETA_ENABLE_COVERAGE`   |  `OFF`  | Enable collecting (test) coverage information                            |
-
+| `DIMETA_ENABLE_FLANG`      |  `OFF`  | Enable Fortran type extraction support                                   |
 
 ### 2.3 Testing
 For testing we require `lit` and `FileCheck`.

--- a/cmake/dimetaToolchain.cmake
+++ b/cmake/dimetaToolchain.cmake
@@ -43,6 +43,8 @@ option(DIMETA_ENABLE_COVERAGE "Enable coverage targets" OFF)
 
 option(DIMETA_TEST_CONFIG "Set logging levels to appropriate levels for test runner to succeed" OFF)
 
+option(DIMETA_ENABLE_FLANG "Enable Fortran support via Flang targets" OFF)
+
 if(DIMETA_TEST_CONFIG)
   set(DIMETA_LOG_LEVEL 3 CACHE STRING "" FORCE)
 else()
@@ -74,6 +76,9 @@ dimeta_find_llvm_progs(DIMETA_CLANG_EXEC "clang-${LLVM_VERSION_MAJOR};clang" DEF
 dimeta_find_llvm_progs(DIMETA_CLANGCXX_EXEC "clang++-${LLVM_VERSION_MAJOR};clang++" DEFAULT_EXE "clang++")
 dimeta_find_llvm_progs(DIMETA_LLC_EXEC "llc-${LLVM_VERSION_MAJOR};llc" DEFAULT_EXE "llc")
 dimeta_find_llvm_progs(DIMETA_OPT_EXEC "opt-${LLVM_VERSION_MAJOR};opt" DEFAULT_EXE "opt")
+if(DIMETA_ENABLE_FLANG)
+  dimeta_find_llvm_progs(DIMETA_FLANG_EXEC "flang-${LLVM_VERSION_MAJOR};flang" ABORT_IF_MISSING ON)
+endif()
 
 if(DIMETA_IS_TOP_LEVEL)
   if(NOT CMAKE_BUILD_TYPE)

--- a/lib/pass/DimetaPass.cpp
+++ b/lib/pass/DimetaPass.cpp
@@ -90,12 +90,18 @@ PassPluginLibraryInfo getPassPluginInfo() {
   const auto callback = [](PassBuilder& PB) {
 #if LLVM_VERSION_MAJOR < 12
     PB.registerPipelineStartEPCallback([&](ModulePassManager& MPM) {
-#else
-    PB.registerPipelineEarlySimplificationEPCallback([&](ModulePassManager& MPM, auto) {
-#endif
       MPM.addPass(dimeta::TestPass());
       return true;
     });
+#elif LLVM_VERSION_MAJOR >= 14
+    PB.registerPipelineEarlySimplificationEPCallback(
+        [&](ModulePassManager& MPM, auto...) { MPM.addPass(dimeta::TestPass()); });
+#else
+    PB.registerPipelineEarlySimplificationEPCallback([&](ModulePassManager& MPM, auto) {
+      MPM.addPass(dimeta::TestPass());
+      return true;
+    });
+#endif
   };
 
   return {LLVM_PLUGIN_API_VERSION, DEBUG_TYPE, "0.0.1", callback};

--- a/lib/type/CMakeLists.txt
+++ b/lib/type/CMakeLists.txt
@@ -12,7 +12,9 @@ set(LIB_SOURCES
   DIUtil.cpp
   DIFinder.cpp
   DIRootType.cpp
+  DIPath.cpp
   DITypeExtractor.cpp
+  DIFortranTypeExtractor.cpp
 )
 
 if(DIMETA_USE_TBAA)

--- a/lib/type/DIFortranTypeExtractor.cpp
+++ b/lib/type/DIFortranTypeExtractor.cpp
@@ -1,0 +1,206 @@
+#include "DIFinder.h"
+#include "DIPath.h"
+#include "DIRootType.h"
+#include "DIUtil.h"
+#include "DataflowAnalysis.h"
+#include "GEP.h"
+#include "TBAA.h"
+#include "ValuePath.h"
+#include "support/Logger.h"
+
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <llvm/IR/DerivedTypes.h>
+#include <optional>
+
+namespace dimeta::fortran {
+
+struct TypeDescritor {
+  // { ptr, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]], ptr, [1 x i64] }
+};
+
+bool is_fortran_descriptor(llvm::Type* type) {
+  LOG_DEBUG("Analyzing " << *type)
+  // Detects if the given type is a Fortran descriptor structure.
+  // Expected pattern:
+  // - Array: { ptr, i64, i32, i8, i8, i8, i8, [n x [3 x i64]], ptr, [n x i64] } (10 elements)
+  // - Scalar: { ptr, i64, i32, i8, i8, i8, i8, ptr, [n x i64] } (9 elements)
+  auto* struct_type = llvm::dyn_cast_or_null<llvm::StructType>(type);
+  if (!struct_type) {
+    return false;
+  }
+  const auto num_elements = struct_type->getNumElements();
+  if (num_elements != 10 && num_elements != 9) {
+    return false;
+  }
+  const bool is_scalar = (num_elements == 9);
+  // 0: ptr (base_addr)
+  if (!struct_type->getElementType(0)->isPointerTy()) {
+    return false;
+  }
+  // 1: i64 (elem_len)
+  if (!struct_type->getElementType(1)->isIntegerTy(64)) {
+    return false;
+  }
+  // 2: i32 (version)
+  if (!struct_type->getElementType(2)->isIntegerTy(32)) {
+    return false;
+  }
+  // 3-6: i8 (rank, type, attribute, f18Addendum)
+  for (unsigned i = 3; i <= 6; ++i) {
+    if (!struct_type->getElementType(i)->isIntegerTy(8)) {
+      return false;
+    }
+  }
+  unsigned current_idx     = 7;
+  llvm::ArrayType* dim_arr = nullptr;
+  if (!is_scalar) {
+    // 7: [n x [3 x i64]] (dimensions)
+    dim_arr = llvm::dyn_cast<llvm::ArrayType>(struct_type->getElementType(current_idx++));
+    if (!dim_arr) {
+      return false;
+    }
+    auto* inner_dim_arr = llvm::dyn_cast<llvm::ArrayType>(dim_arr->getElementType());
+    if (!inner_dim_arr || inner_dim_arr->getNumElements() != 3 || !inner_dim_arr->getElementType()->isIntegerTy(64)) {
+      return false;
+    }
+  }
+  // 8 (or 7): ptr (type descriptor pointer)
+  if (!struct_type->getElementType(current_idx++)->isPointerTy()) {
+    return false;
+  }
+  // 9 (or 8): [n x i64] (addendum)
+  auto* addendum_arr = llvm::dyn_cast<llvm::ArrayType>(struct_type->getElementType(current_idx++));
+  if (!addendum_arr || !addendum_arr->getElementType()->isIntegerTy(64)) {
+    return false;
+  }
+  if (dim_arr && dim_arr->getNumElements() != addendum_arr->getNumElements()) {
+    return false;
+  }
+  return true;
+}
+
+template <typename Iter>
+std::optional<llvm::DIType*> reset_ditype(llvm::DIType* type_to_reset, const dataflow::ValuePath& path,
+                                          const Iter& path_iter, type::dipath::ValueToDiPath& logged_dipath) {
+  std::optional<llvm::DIType*> type = type_to_reset;
+
+  const auto& current_value = path_iter;
+  LOG_DEBUG("Type to reset: " << log::ditype_str(*type));
+  LOG_DEBUG(">> based on IR: " << **current_value);
+
+  if (llvm::isa<llvm::GEPOperator>(*current_value)) {
+    LOG_DEBUG("Reset based on GEP")
+    auto* gep                     = llvm::cast<llvm::GEPOperator>(*current_value);
+    const bool fortran_descriptor = fortran::is_fortran_descriptor(gep->getSourceElementType());
+    if (!fortran_descriptor) {
+      const auto gep_result = gep::extract_gep_dereferenced_type(type.value(), *gep);
+      if (gep_result.member && !gep_result.use_type) {
+        LOG_DEBUG("Using gep member type result")
+        type = gep_result.member;
+      } else {
+        type = gep_result.type;
+      }
+    }
+  } else if (const auto* load = llvm::dyn_cast<llvm::LoadInst>(*current_value)) {
+    LOG_DEBUG("Reset based on load " << *load)
+    // TODO
+  } else if (const auto* store_inst = llvm::dyn_cast<llvm::StoreInst>(*current_value)) {
+    LOG_DEBUG("Reset based on store " << *store_inst)
+
+  } else {
+    LOG_DEBUG(">> skipping: " << **current_value);
+  }
+
+  logged_dipath.emplace_back(*current_value, type.value_or(nullptr));
+
+  return type;
+}
+
+std::optional<llvm::DIType*> extract(const dataflow::CallValuePath& call_path, std::optional<llvm::DIType*> type) {
+  assert(call_path.call.has_value() && "Expected a Fortran call handle");
+  // Fortran workaround:
+  // If _FortranAAllocatableAllocate called on a global directly, assume first member is actually allocated, see
+  // test 08_bounds_nogep.f90 vs. 08_bounds.f90:
+  // @_QMtea_moduleEchunk = global %_QMtea_moduleTchunktype
+  // call i32 @_FortranAAllocatableAllocate(ptr @_QMtea_moduleEchunk, ...), !dbg !30
+
+  LOG_DEBUG("Fortran workaround for _FortranAAllocatableAllocate")
+
+  type::dipath::ValueToDiPath dipath;
+
+  const auto path_end = call_path.path.path_to_value.rend();
+  for (auto path_iter = call_path.path.path_to_value.rbegin(); path_iter != path_end; ++path_iter) {
+    LOG_DEBUG("Extracted type: " << log::ditype_str(*type));
+    type = reset_ditype(type.value(), call_path.path, path_iter, dipath).value_or(type.value());
+    LOG_DEBUG("reset_ditype result " << log::ditype_str(type.value_or(nullptr)) << "\n")
+    if (!type) {
+      break;
+    }
+  }
+
+  auto* ditype_final = type.value();
+
+  const bool only_global = [&]() -> bool {
+    bool is_global_target = llvm::isa<llvm::GlobalVariable>(*call_path.path.value()) && call_path.path.size() == 1;
+
+    // 09_local_bounds.f90 optimized: (alloca -> memcpy of global) [->] allocatable:
+    for (const auto* user : call_path.path.value().value()->users()) {
+      if (llvm::MemCpyInst::classof(user)) {
+        is_global_target = llvm::isa<llvm::GlobalVariable>(llvm::cast<llvm::MemCpyInst>(user)->getSource());
+      }
+    }
+    return is_global_target;
+  }();
+
+  if (only_global && llvm::isa<llvm::DICompositeType>(ditype_final)) {
+    LOG_DEBUG("Reset fortran allocated type " << log::ditype_str(ditype_final))
+
+    auto struct_mem = di::util::resolve_byte_offset_to_member_of(llvm::cast<llvm::DICompositeType>(ditype_final), 0);
+    if (struct_mem) {
+      dipath.emplace_back(nullptr, struct_mem->type_of_member.value_or(ditype_final), "Allocatable of global type");
+    }
+  }
+
+  const auto global_inheritance = [&]() -> std::optional<llvm::GlobalVariable*> {
+    const auto* global_target = llvm::dyn_cast<llvm::GlobalVariable>(*call_path.path.value());
+    if (!global_target) {
+      return {};
+    }
+    for (const auto* user : global_target->users()) {
+      if (auto* call = llvm::dyn_cast<llvm::CallBase>(user)) {
+        auto target    = call->getCalledFunction();
+        auto is_target = target ? target->getName() == ("_FortranAAllocatableInitDerivedForAllocate") : false;
+        if (is_target) {
+          auto global = llvm::dyn_cast<llvm::GlobalVariable>(call->getOperand(1));
+          if (global) {
+            return {global};
+          }
+          break;
+        }
+      }
+    }
+    return {};
+  };
+  auto type_inheritance = global_inheritance();
+  if (type_inheritance) {
+    LOG_DEBUG("Found inheritance, type descriptor: " << **type_inheritance)
+  }
+
+  LOG_DEBUG("Final mapping\n" << dipath)
+
+  return dipath.final_type();
+}
+}  // namespace dimeta::fortran

--- a/lib/type/DIFortranTypeExtractor.h
+++ b/lib/type/DIFortranTypeExtractor.h
@@ -1,0 +1,20 @@
+#ifndef LIB_TYPE_DIFORTRANTYPEEXTRACTOR
+#define LIB_TYPE_DIFORTRANTYPEEXTRACTOR
+
+#include <optional>
+
+namespace llvm {
+class DIType;
+class Type;
+}  // namespace llvm
+
+namespace dimeta::dataflow {
+struct CallValuePath;
+}
+
+namespace dimeta::fortran {
+bool is_fortran_descriptor(llvm::Type* type);
+std::optional<llvm::DIType*> extract(const dataflow::CallValuePath& call_path, std::optional<llvm::DIType*>);
+}  // namespace dimeta::fortran
+
+#endif /* LIB_TYPE_DIFORTRANTYPEEXTRACTOR */

--- a/lib/type/DIParser.cpp
+++ b/lib/type/DIParser.cpp
@@ -39,6 +39,8 @@ class DIEventVisitor : public visitor::DINodeVisitor<DIEventVisitor> {
 
   bool visitBasicType(const llvm::DIBasicType*);
 
+  bool visitStringType(const llvm::DIStringType*);
+
   bool visitDerivedType(const llvm::DIDerivedType*);
 
   bool visitCompositeType(const llvm::DICompositeType*);
@@ -49,6 +51,8 @@ class DIEventVisitor : public visitor::DINodeVisitor<DIEventVisitor> {
   bool visitRecurringCompositeType(const llvm::DICompositeType*);
 
   void leaveBasicType(const llvm::DIBasicType*);
+
+  void leaveStringType(const llvm::DIStringType*);
 
   void leaveCompositeType(const llvm::DICompositeType*);
 
@@ -80,6 +84,12 @@ bool DIEventVisitor::visitBasicType(const llvm::DIBasicType* basic_type) {
 
   events_.make_fundamental(current_);
 
+  return true;
+}
+
+bool DIEventVisitor::visitStringType(const llvm::DIStringType* string_type) {
+  current_.type = const_cast<llvm::DIStringType*>(string_type);
+  events_.make_string(current_);
   return true;
 }
 
@@ -206,6 +216,12 @@ bool DIEventVisitor::visitCompositeType(const llvm::DICompositeType* composite_t
     current_.is_vector = composite_type->isVector();
     current_.dwarf_tags.emplace_back(current_.is_vector ? static_cast<unsigned>(state::CustomDwarfTag::kVector)
                                                         : static_cast<unsigned>(llvm::dwarf::DW_TAG_array_type));
+    if (composite_type->getRawAssociated()) {
+      // Fortran pointer allocations use "associated" tag
+      LOG_DEBUG("Associated: array of pointer")
+      current_.dwarf_tags.emplace_back(llvm::dwarf::DW_TAG_pointer_type);
+    }
+
     current_.arrays.emplace_back(
         state::MetaData::ArrayData{composite_type->getSizeInBits(), Extent{0}, {}, composite_type->isVector()});
     // current_.array_size_bits =composite_type->getSizeInBits();
@@ -268,6 +284,10 @@ void DIEventVisitor::leaveCompositeType(const llvm::DICompositeType* composite_t
 }
 
 void DIEventVisitor::leaveBasicType(const llvm::DIBasicType*) {
+  current_ = state::MetaData{};
+}
+
+void DIEventVisitor::leaveStringType(const llvm::DIStringType*) {
   current_ = state::MetaData{};
 }
 

--- a/lib/type/DIParser.h
+++ b/lib/type/DIParser.h
@@ -71,6 +71,7 @@ class DIParseEvents {
   virtual void make_fundamental(const state::MetaData&)   = 0;
   virtual void make_function_ptr(const state::MetaData&)  = 0;
   virtual void make_void_ptr(const state::MetaData&)      = 0;
+  virtual void make_string(const state::MetaData&)        = 0;
   virtual void make_vtable(const state::MetaData&)        = 0;
   virtual void make_enum_member(const state::MetaData&)   = 0;
   virtual void make_composite(const state::MetaData&)     = 0;

--- a/lib/type/DIPath.cpp
+++ b/lib/type/DIPath.cpp
@@ -1,0 +1,72 @@
+//  llvm-dimeta library
+//  Copyright (c) 2022-2025 llvm-dimeta authors
+//  Distributed under the BSD 3-Clause license.
+//  (See accompanying file LICENSE)
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "DIPath.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+
+namespace dimeta::type::dipath {
+
+void ValueToDiPath::emplace_back(const llvm::Value* val, llvm::DIType* mapped_di_type, const std::string reason) {
+  path_to_ditype.emplace_back(IRMapping{val, mapped_di_type, std::move(reason)});
+}
+
+std::optional<llvm::DIType*> ValueToDiPath::final_type() const {
+  if (path_to_ditype.empty()) {
+    return {};
+  }
+  const auto& ditype = path_to_ditype.back();
+  return ditype.mapped != nullptr ? std::optional{ditype.mapped} : std::nullopt;
+}
+
+llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const ValueToDiPath& vdp) {
+#if DIMETA_LOG_LEVEL > 2  // FIXME: For coverage
+  const auto& mappings = vdp.path_to_ditype;
+  if (mappings.empty()) {
+    os << "[]";
+    return os;
+  }
+
+  os << "[\n";
+  for (auto it = mappings.begin(); it != mappings.end(); ++it) {
+    const auto& mapping = *it;
+    os << "  {\n";
+    os << "    IR: ";
+    if (mapping.value) {
+      mapping.value->print(os, true);
+    } else {
+      os << "null";
+    }
+    os << ",\n";
+
+    os << "    DI: ";
+    if (mapping.mapped) {
+      os << log::ditype_str(mapping.mapped);
+    } else {
+      os << "null";
+    }
+
+    if (!mapping.reason.empty()) {
+      os << ",\n";
+      os << "    Reason: \"" << mapping.reason << "\"\n";
+    } else {
+      os << "\n";
+    }
+    os << "  }";
+    if (std::next(it) != mappings.end()) {
+      os << ",";
+    }
+    os << "\n";
+  }
+  os << "]";
+#endif
+  return os;
+}
+
+}  // namespace dimeta::type::dipath

--- a/lib/type/DIPath.h
+++ b/lib/type/DIPath.h
@@ -1,0 +1,44 @@
+//  llvm-dimeta library
+//  Copyright (c) 2022-2025 llvm-dimeta authors
+//  Distributed under the BSD 3-Clause license.
+//  (See accompanying file LICENSE)
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+#ifndef LIB_TYPE_DIPATH_H
+#define LIB_TYPE_DIPATH_H
+
+#include "support/Logger.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/Value.h"
+
+#include <optional>
+#include <string>
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace dimeta::type::dipath {
+
+struct IRMapping {
+  const llvm::Value* value{nullptr};
+  llvm::DIType* mapped{nullptr};
+  std::string reason;
+};
+
+struct ValueToDiPath {
+  llvm::SmallVector<IRMapping, 8> path_to_ditype;
+
+  void emplace_back(const llvm::Value* val, llvm::DIType* mapped_di_type, const std::string reason = "");
+
+  std::optional<llvm::DIType*> final_type() const;
+};
+
+llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const ValueToDiPath& vdp);
+
+}  // namespace dimeta::type::dipath
+
+#endif  // LIB_TYPE_DIPATH_H

--- a/lib/type/DIRootType.cpp
+++ b/lib/type/DIRootType.cpp
@@ -8,6 +8,7 @@
 #include "DIRootType.h"
 
 #include "DIFinder.h"
+#include "DITypeExtractor.h"
 #include "DataflowAnalysis.h"
 #include "DefUseAnalysis.h"
 #include "Dimeta.h"
@@ -141,6 +142,17 @@ std::optional<llvm::DIType*> type_of_argument(const llvm::Argument& argument) {
   return {};
 }
 
+std::optional<llvm::DIType*> type_of_global(const llvm::GlobalVariable* global_variable) {
+  auto dbg_md = global_variable->getMetadata("dbg");
+  if (!dbg_md) {
+    return {};
+  }
+  if (auto* global_expression = llvm::dyn_cast<llvm::DIGlobalVariableExpression>(dbg_md)) {
+    return global_expression->getVariable()->getType();
+  }
+  return {};
+}
+
 }  // namespace helper
 
 std::optional<llvm::DIType*> find_type_root(const dataflow::CallValuePath& call_path) {
@@ -199,6 +211,60 @@ std::optional<llvm::DIType*> find_type_root(const dataflow::CallValuePath& call_
       LOG_DEBUG("Called function not found for call base " << *call_inst)
       return {};
     }
+    {
+      // Fortran extension
+      // TODO: handle memcpy indirection
+      if (MemCpyInst::classof(call_inst)) {
+        LOG_DEBUG("Found memcpy, take source " << *call_inst->getArgOperand(1))
+        if (auto alloca = llvm::dyn_cast<llvm::AllocaInst>(call_inst->getArgOperand(1))) {
+          // auto type_of_alloca = find_type_root(dataflow::CallValuePath{std::nullopt, call_path.path});
+          auto local_di_var = difinder::find_local_variable(alloca);
+          if (local_di_var) {
+            LOG_DEBUG("Found type through memcpy")
+            return local_di_var.value()->getType();
+          }
+
+          for (auto user : alloca->users()) {
+            if (auto store = llvm::dyn_cast<llvm::StoreInst>(user)) {
+              if (const auto* argument = llvm::dyn_cast<llvm::Argument>(store->getValueOperand())) {
+                LOG_DEBUG("Found type through memcpy (argument)")
+                return helper::type_of_argument(*argument);
+              }
+            }
+          }
+          if (call_path.path.contains(alloca)) {
+            LOG_DEBUG("Alloca contained in path, skipping further analysis")
+            return {};
+          }
+
+          LOG_DEBUG("Dataflow analysis of alloca")
+          auto paths_from_alloca = dataflow::path_from_alloca(alloca);
+          for (auto& path : paths_from_alloca) {
+            LOG_DEBUG("Path from alloca " << path)
+            auto type_of_alloca = find_type_root(dataflow::CallValuePath{std::nullopt, path});
+            if (type_of_alloca) {
+              return type_of_alloca;
+            }
+          }
+        } else if (auto* global = llvm::dyn_cast<llvm::GlobalVariable>(call_inst->getArgOperand(1))) {
+          LOG_DEBUG("Memcpy of global variable detected")
+          return helper::type_of_global(global);
+        } else if (auto* gep = llvm::dyn_cast<llvm::GetElementPtrInst>(call_inst->getArgOperand(1))) {
+          LOG_DEBUG("Memcpy of GEP detected")
+          auto backward_paths_from_gep = dataflow::experimental::path_from_value(gep);
+          for (auto& path : backward_paths_from_gep) {
+            LOG_DEBUG("Path from gep " << path)
+            // Test fortran 16_...f90, allocation "ALLOCATE(chunk%tiles(t)%field%density ...)"
+            // Use type::find_type to resolve the nested member type from the GEP access path
+            auto type_of_member = type::find_type(dataflow::CallValuePath{std::nullopt, path});
+            if (type_of_member) {
+              LOG_DEBUG("Detected gep member type " << log::ditype_str(type_of_member.value()))
+              return type_of_member;
+            }
+          }
+        }
+      }
+    }
 
     dimeta::memory::MemOps ops;
     if (ops.allocKind(called_f->getName())) {
@@ -242,14 +308,7 @@ std::optional<llvm::DIType*> find_type_root(const dataflow::CallValuePath& call_
   }
 
   if (const auto* global_variable = llvm::dyn_cast<llvm::GlobalVariable>(root_value)) {
-    auto dbg_md = global_variable->getMetadata("dbg");
-    if (!dbg_md) {
-      return {};
-    }
-    if (auto* global_expression = llvm::dyn_cast<llvm::DIGlobalVariableExpression>(dbg_md)) {
-      return global_expression->getVariable()->getType();
-    }
-    return {};
+    return helper::type_of_global(global_variable);
   }
 
   if (const auto* argument = llvm::dyn_cast<llvm::Argument>(root_value)) {

--- a/lib/type/DIRootType.h
+++ b/lib/type/DIRootType.h
@@ -5,8 +5,8 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-#ifndef DIMETA_DIROOTTYPE_H
-#define DIMETA_DIROOTTYPE_H
+#ifndef LIB_TYPE_DIROOTTYPE
+#define LIB_TYPE_DIROOTTYPE
 
 #include <optional>
 
@@ -25,4 +25,4 @@ std::optional<llvm::DIType*> find_type_root(const dataflow::CallValuePath& path)
 
 }
 
-#endif
+#endif /* LIB_TYPE_DIROOTTYPE */

--- a/lib/type/DITypeExtractor.cpp
+++ b/lib/type/DITypeExtractor.cpp
@@ -7,10 +7,13 @@
 //
 
 #include "DIFinder.h"
+#include "DIFortranTypeExtractor.h"
+#include "DIPath.h"
 #include "DIRootType.h"
 #include "DIUtil.h"
 #include "DataflowAnalysis.h"
 #include "DefUseAnalysis.h"
+#include "DimetaData.h"
 #include "GEP.h"
 #include "TBAA.h"
 #include "Util.h"
@@ -127,76 +130,6 @@ bool store_to_array_gep(const llvm::StoreInst* store) {
   return detail::is_array_gep_with_non_const_indices(gep.value());
 }
 
-namespace dipath {
-
-struct IRMapping {
-  const llvm::Value* value{nullptr};
-  llvm::DIType* mapped{nullptr};
-  std::string reason;
-};
-
-struct ValueToDiPath {
-  llvm::SmallVector<IRMapping, 8> path_to_ditype;
-
-  void emplace_back(const llvm::Value* val, llvm::DIType* mapped_di_type, const std::string reason = "") {
-    path_to_ditype.emplace_back(IRMapping{val, mapped_di_type, std::move(reason)});
-  }
-
-  std::optional<llvm::DIType*> final_type() const {
-    if (path_to_ditype.empty()) {
-      return {};
-    }
-    const auto& ditype = path_to_ditype.back();
-    return ditype.mapped != nullptr ? std::optional{ditype.mapped} : std::nullopt;
-  }
-};
-
-llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const ValueToDiPath& vdp) {
-#if DIMETA_LOG_LEVEL > 2  // FIXME: For coverage
-  const auto& mappings = vdp.path_to_ditype;
-  // os << "ValueToDiPath: ";  // Prefix to identify the type being printed
-  if (mappings.empty()) {
-    os << "[]";
-    return os;
-  }
-  const auto mapping_to_string = [](const IRMapping& mapping) -> std::string {
-    std::string str_buffer;
-    llvm::raw_string_ostream stream(str_buffer);
-
-    stream << "{IR: ";
-    if (mapping.value) {
-      // mapping.value->printAsOperand(stream, true);
-      mapping.value->print(stream, true);
-    } else {
-      stream << "null";
-    }
-
-    stream << "; DI: ";
-    if (mapping.mapped) {
-      stream << log::ditype_str(mapping.mapped);
-    } else {
-      stream << "null";
-    }
-
-    if (!mapping.reason.empty()) {
-      stream << ", Reason: \"" << mapping.reason << "\"}";
-    }
-    return stream.str();
-  };
-
-  os << "[" << mapping_to_string(mappings.front());
-  std::for_each(std::next(mappings.begin()), mappings.end(), [&](const IRMapping& mapping_item) {
-    os << " --> ";
-    os << mapping_to_string(mapping_item);
-  });
-
-  os << "]";
-#endif
-  return os;
-}
-
-}  // namespace dipath
-
 std::optional<llvm::DIType*> reset_load_related_basic(const dataflow::ValuePath& path, llvm::DIType* type_to_reset,
                                                       const llvm::LoadInst* load) {
   auto* type = type_to_reset;
@@ -204,6 +137,17 @@ std::optional<llvm::DIType*> reset_load_related_basic(const dataflow::ValuePath&
   if (load_to<llvm::GlobalVariable>(load) || load_to<llvm::AllocaInst>(load)) {
     LOG_DEBUG("Do not reset DIType based on load to global,alloca")
     return type;
+  }
+
+  // Fortran test 11_...F90:
+  if (auto gep = detail::get_operand_to<llvm::GetElementPtrInst>(load)) {
+    const bool fortran_descriptor = fortran::is_fortran_descriptor(gep.value()->getSourceElementType());
+    if (fortran_descriptor) {
+      // auto comp   = di::util::desugar(*type);
+      // auto result = di::util::resolve_byte_offset_to_member_of(comp.value(), 0);
+      // return result->type_of_member;
+      return type;
+    }
   }
 
   if (di::util::is_array_member(*type)) {
@@ -234,9 +178,10 @@ std::optional<llvm::DIType*> reset_load_related_basic(const dataflow::ValuePath&
   const bool last_load     = path.start_value().value_or(nullptr) == load;
   const bool is_not_member = !di::util::is_member(*type);
   if (is_not_member || last_load) {
-    const bool is_not_arg_load  = !load_to<llvm::Argument>(load);
-    const bool is_not_array_gep = !load_of_array_gep(load) && !load_for_array_gep(load);
-    if (is_not_array_gep && (is_not_arg_load || last_load)) {
+    const bool is_not_arg_load = !load_to<llvm::Argument>(load);
+    // test Fortran 17 (first allocate): SROA optimization: load on argument selects first member of struct:
+    // const bool is_not_array_gep = !load_of_array_gep(load) && !load_for_array_gep(load);
+    if (!load_of_array_gep(load)) {  // && (is_not_arg_load || last_load)) {
       if (auto resolved = try_resolve_to_first_member(type)) {
         return resolved.value();
       }
@@ -322,9 +267,16 @@ std::optional<llvm::DIType*> reset_store_related_basic(const dataflow::ValuePath
 
   if (di::util::is_array_member(*type)) {
     auto* member_base               = derived_type->getBaseType();
-    const bool is_array_type_member = member_base->getTag() == llvm::dwarf::DW_TAG_array_type;
+    const bool is_array_type_member = di::util::is_array(*member_base);
     if (is_array_type_member) {
-      return llvm::cast<llvm::DICompositeType>(member_base)->getBaseType();
+      LOG_DEBUG("Store to member with type array, looks through to base type of array")
+      // Fortran: test 17, 18: with optim, we do not detect the tag "array" otherwise:
+      auto base_of_member = llvm::cast<llvm::DICompositeType>(member_base)->getBaseType();
+      if (di::util::is_pointer(*base_of_member)) {
+        return base_of_member;
+      }
+      return member_base;
+      // return llvm::cast<llvm::DICompositeType>(member_base)->getBaseType();
     }
   }
 
@@ -359,13 +311,20 @@ std::optional<llvm::DIType*> reset_ditype(llvm::DIType* type_to_reset, const dat
 
   if (llvm::isa<llvm::GEPOperator>(*current_value)) {
     LOG_DEBUG("Reset based on GEP")
-    auto* gep             = llvm::cast<llvm::GEPOperator>(*current_value);
-    const auto gep_result = gep::extract_gep_dereferenced_type(type.value(), *gep);
-    if (gep_result.member && !gep_result.use_type) {
-      LOG_DEBUG("Using gep member type result")
-      type = gep_result.member;
+    const llvm::GEPOperator* gep_op = llvm::cast<llvm::GEPOperator>(*current_value);
+    const bool fortran_descriptor   = fortran::is_fortran_descriptor(gep_op->getSourceElementType());
+    if (!fortran_descriptor) {
+      const auto gep_result = gep::extract_gep_dereferenced_type(type.value(), *gep_op);
+      if (gep_result.member && !gep_result.use_type) {
+        LOG_DEBUG("Using gep member type result")
+        type = gep_result.member;
+      } else if (gep_result.type) {
+        LOG_DEBUG("Using gep type result")
+        type = gep_result.type;
+      }
     } else {
-      type = gep_result.type;
+      // Fortran test 11_...F90:
+      LOG_DEBUG("Skipping GEP, Fortran descriptor")
     }
   } else if (const auto* load = llvm::dyn_cast<llvm::LoadInst>(*current_value)) {
     LOG_DEBUG("Reset based on load")
@@ -375,8 +334,8 @@ std::optional<llvm::DIType*> reset_ditype(llvm::DIType* type_to_reset, const dat
     type = reset::reset_store_related_basic(path, type.value(), store_inst);
   } else {
     LOG_DEBUG(">> skipping");
-    logged_dipath.emplace_back(*current_value, type.value_or(nullptr));
-    return type;
+    // logged_dipath.emplace_back(*current_value, type.value_or(nullptr));
+    // return type;
   }
 
   logged_dipath.emplace_back(*current_value, type.value_or(nullptr));
@@ -394,7 +353,20 @@ std::optional<llvm::DIType*> find_type(const dataflow::CallValuePath& call_path)
     return {};
   }
 
-  reset::dipath::ValueToDiPath dipath;
+  LOG_DEBUG("IR path to analyze " << call_path.path)
+
+  if (call_path.call) {
+    const auto function       = call_path.call.value()->getCalledFunction();
+    const auto fortran_handle = function ? util::starts_with_any_of(function->getName(), "_FortranAAllocatableAllocate",
+                                                                    "_FortranAPointerAllocate")
+                                         : false;
+    if (fortran_handle) {
+      LOG_DEBUG("Fortran handle found " << function->getName())
+      return fortran::extract(call_path, type);
+    }
+  }
+
+  dipath::ValueToDiPath dipath;
 
   const auto path_end = call_path.path.path_to_value.rend();
   for (auto path_iter = call_path.path.path_to_value.rbegin(); path_iter != path_end; ++path_iter) {

--- a/lib/type/DITypeExtractor.h
+++ b/lib/type/DITypeExtractor.h
@@ -5,8 +5,8 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-#ifndef DIMETA_DITYPEEXTRACTOR_H
-#define DIMETA_DITYPEEXTRACTOR_H
+#ifndef LIB_TYPE_DITYPEEXTRACTOR
+#define LIB_TYPE_DITYPEEXTRACTOR
 
 #include <optional>
 
@@ -24,4 +24,4 @@ std::optional<llvm::DIType*> find_type(const dataflow::CallValuePath& call_path)
 
 }
 
-#endif
+#endif /* LIB_TYPE_DITYPEEXTRACTOR */

--- a/lib/type/DIUtil.cpp
+++ b/lib/type/DIUtil.cpp
@@ -65,6 +65,11 @@ class DIPrinter : public visitor::DINodeVisitor<DIPrinter> {
     return true;
   }
 
+  bool visitStringType(const llvm::DIStringType* string_type) {
+    outp_ << llvm::left_justify("", width() + 3) << no_pointer_str(*string_type) << "\n";
+    return true;
+  }
+
   bool visitDerivedType(const llvm::DIDerivedType* derived_type) {
     outp_ << llvm::left_justify("", width()) << no_pointer_str(*derived_type) << "\n";
     return true;
@@ -104,7 +109,8 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
   }
 
   bool visitDerivedType(const llvm::DIDerivedType* derived_ty) {
-    if (derived_ty->getTag() != llvm::dwarf::DW_TAG_member) {
+    // if (derived_ty->getTag() != llvm::dwarf::DW_TAG_member) {
+    if (!util::is_non_static_member(*derived_ty)) {
       return true;
     }
     // assert(derived_ty->getTag() == llvm::dwarf::DW_TAG_member && "Expected member element in composite ty");
@@ -124,10 +130,9 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
 
       this->outermost_candidate_.emplace(StructMember{const_cast<llvm::DIDerivedType*>(derived_ty), member_base_type});
 
-      if (is_pointer_like(*member_base_type) || member_base_type->getTag() == llvm::dwarf::DW_TAG_array_type) {
-        LOG_DEBUG("Terminating recursion, found pointer-like "
-                  << is_pointer_like(*member_base_type) << " or array-like "
-                  << (member_base_type->getTag() == llvm::dwarf::DW_TAG_array_type))
+      if (is_pointer_like(*member_base_type) || is_array(*member_base_type)) {
+        LOG_DEBUG("Terminating recursion, found pointer-like " << is_pointer_like(*member_base_type)
+                                                               << " or array-like " << is_array(*member_base_type))
         return false;  // if offset matches, and its a pointer-like, we do not need to recurse.
       }
 
@@ -153,9 +158,10 @@ std::optional<StructMember> resolve_byte_offset_to_member_of(const llvm::DICompo
   return visitor.result();
 }
 
-bool is_pointer(const llvm::DIType& di_type) {
+bool is_pointer(const llvm::DIType& di_type, bool count_reference) {
   if (const auto* type = llvm::dyn_cast<llvm::DIDerivedType>(&di_type)) {
-    return type->getTag() == llvm::dwarf::DW_TAG_reference_type || type->getTag() == llvm::dwarf::DW_TAG_pointer_type;
+    return (type->getTag() == llvm::dwarf::DW_TAG_reference_type && count_reference) ||
+           type->getTag() == llvm::dwarf::DW_TAG_pointer_type;
   }
   return false;
 }
@@ -229,6 +235,30 @@ bool is_array_member(const llvm::DINode& elem) {
 bool is_array(const llvm::DINode& elem) {
   auto comp = llvm::dyn_cast<llvm::DICompositeType>(&elem);
   return (comp != nullptr) && comp->getTag() == llvm::dwarf::DW_TAG_array_type;
+}
+
+bool is_string(const llvm::DINode& elem) {
+  return elem.getTag() == llvm::dwarf::DW_TAG_string_type;
+}
+
+bool is_inheritance(const llvm::DINode& elem) {
+  return elem.getTag() == llvm::dwarf::DW_TAG_inheritance;
+}
+
+bool is_enum(const llvm::DINode& elem) {
+  return elem.getTag() == llvm::dwarf::DW_TAG_enumeration_type;
+}
+
+bool is_struct_or_class(const llvm::DINode& elem) {
+  return elem.getTag() == llvm::dwarf::DW_TAG_structure_type || elem.getTag() == llvm::dwarf::DW_TAG_class_type;
+}
+
+bool is_typedef(const llvm::DINode& elem) {
+  return elem.getTag() == llvm::dwarf::DW_TAG_typedef;
+}
+
+bool is_union(const llvm::DINode& elem) {
+  return elem.getTag() == llvm::dwarf::DW_TAG_union_type;
 }
 
 }  // namespace dimeta::di::util

--- a/lib/type/DIUtil.cpp
+++ b/lib/type/DIUtil.cpp
@@ -105,7 +105,7 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
   bool visitCompositeType(const llvm::DICompositeType* composite) const {
     LOG_DEBUG("visitCompositeType: " << log::ditype_str(composite) << ": " << composite->getName()
                                      << " index: " << byte_index_ << " offset base: " << this->offset_base_);
-    return true;
+    return !terminate;
   }
 
   bool visitDerivedType(const llvm::DIDerivedType* derived_ty) {
@@ -133,6 +133,7 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
       if (is_pointer_like(*member_base_type) || is_array(*member_base_type)) {
         LOG_DEBUG("Terminating recursion, found pointer-like " << is_pointer_like(*member_base_type)
                                                                << " or array-like " << is_array(*member_base_type))
+        terminate = true;
         return false;  // if offset matches, and its a pointer-like, we do not need to recurse.
       }
 
@@ -150,6 +151,7 @@ struct DestructureComposite : visitor::DINodeVisitor<DestructureComposite> {
   size_t byte_index_;
   size_t offset_base_{};
   std::optional<StructMember> outermost_candidate_{};
+  bool terminate{false};
 };
 
 std::optional<StructMember> resolve_byte_offset_to_member_of(const llvm::DICompositeType* composite, size_t offset) {

--- a/lib/type/DIUtil.h
+++ b/lib/type/DIUtil.h
@@ -34,7 +34,7 @@ struct StructMember {
 std::optional<StructMember> resolve_byte_offset_to_member_of(const llvm::DICompositeType* composite,
                                                              size_t byte_offset);
 
-bool is_pointer(const llvm::DIType& di_type);
+bool is_pointer(const llvm::DIType& di_type, bool count_reference = true);
 bool is_pointer_like(const llvm::DIType& di_type);
 bool is_non_static_member(const llvm::DINode& elem);
 bool is_member(const llvm::DINode& elem);
@@ -44,6 +44,12 @@ std::optional<llvm::DICompositeType*> desugar(llvm::DIType& qualified_composite,
 // bool has_tbaa(const llvm::Instruction&);
 bool is_array_member(const llvm::DINode& elem);
 bool is_array(const llvm::DINode& elem);
+bool is_string(const llvm::DINode& elem);
+bool is_inheritance(const llvm::DINode& elem);
+bool is_enum(const llvm::DINode& elem);
+bool is_struct_or_class(const llvm::DINode& elem);
+bool is_typedef(const llvm::DINode& elem);
+bool is_union(const llvm::DINode& elem);
 
 }  // namespace dimeta::di::util
 

--- a/lib/type/DIVisitor.h
+++ b/lib/type/DIVisitor.h
@@ -44,6 +44,7 @@ class DINodeVisitor {
     return invoke_if<DIBasicType>(&DINodeVisitor::traverseBasicType, std::forward<T>(type)) ||
            invoke_if<DIDerivedType>(&DINodeVisitor::traverseDerivedType, std::forward<T>(type)) ||
            invoke_if<DICompositeType>(&DINodeVisitor::traverseCompositeType, std::forward<T>(type)) ||
+           invoke_if<DIStringType>(&DINodeVisitor::traverseStringType, std::forward<T>(type)) ||
            invoke_if<DILocalVariable>(&DINodeVisitor::traverseVariable, std::forward<T>(type)) ||
            invoke_if<DIGlobalVariable>(&DINodeVisitor::traverseVariable, std::forward<T>(type)) ||
            invoke_if<DIEnumerator>(&DINodeVisitor::traverseNode, std::forward<T>(type)) ||
@@ -142,6 +143,21 @@ class DINodeVisitor {
   }
 
   bool visitBasicType(const llvm::DIBasicType*) {
+    return true;
+  }
+
+  bool traverseStringType(const llvm::DIStringType* string_type) {
+    ++depth_var_;
+    const auto exit = dimeta::util::create_scope_exit([&]() {
+      get().leaveStringType(string_type);
+      assert(depth_var_ > 0);
+      --depth_var_;
+    });
+    get().enterStringType(string_type);
+    return get().visitStringType(string_type);
+  }
+
+  bool visitStringType(const llvm::DIStringType*) {
     return true;
   }
 
@@ -249,6 +265,10 @@ class DINodeVisitor {
   void enterBasicType(const llvm::DIBasicType*) {
   }
   void leaveBasicType(const llvm::DIBasicType*) {
+  }
+  void enterStringType(const llvm::DIStringType*) {
+  }
+  void leaveStringType(const llvm::DIStringType*) {
   }
   void enterDerivedType(const llvm::DIDerivedType*) {
   }

--- a/lib/type/DataflowAnalysis.cpp
+++ b/lib/type/DataflowAnalysis.cpp
@@ -8,6 +8,8 @@
 #include "DataflowAnalysis.h"
 
 #include "DefUseAnalysis.h"
+#include "Dimeta.h"
+#include "Util.h"
 #include "support/Logger.h"
 
 #include "llvm/ADT/TinyPtrVector.h"
@@ -30,6 +32,8 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
+#include <cstdint>
+#include <llvm/IR/GlobalValue.h>
 #include <optional>
 
 namespace llvm {
@@ -68,7 +72,18 @@ llvm::SmallVector<ValuePath, 4> type_for_heap_call(const llvm::CallBase* call) {
   LOG_DEBUG("Find heap-call to anchor w.r.t. " << *call)
   // Anchor can be anything like function call "malloc -> .. -> foo(malloc)" or "malloc -> .. -> store" etc.
   MallocAnchorMatcher malloc_forward_anchor_finder;
-  value_traversal.traverse(call, malloc_forward_anchor_finder, should_search);
+  // value_traversal.traverse(call, malloc_forward_anchor_finder, should_search);
+  value_traversal.traverse_custom(call, malloc_forward_anchor_finder, should_search,
+                                  [](const ValuePath& val) -> std::optional<decltype(val.value().value()->users())> {
+                                    const auto value = val.value();
+                                    if (!value) {
+                                      return {};
+                                    }
+                                    if (auto* store = llvm::dyn_cast<llvm::StoreInst>(value.value())) {
+                                      return store->getPointerOperand()->users();
+                                    }
+                                    return value.value()->users();
+                                  });
 
   // backward: find paths from anchor (store) to alloca/argument/global etc.
   MallocTargetMatcher malloc_anchor_backtrack;
@@ -82,6 +97,7 @@ llvm::SmallVector<ValuePath, 4> type_for_heap_call(const llvm::CallBase* call) {
     if (auto* store_inst = dyn_cast_or_null<StoreInst>(anchor_path.value().value_or(nullptr))) {
       if (store_inst->getPointerOperand() == call) {
         // see test heap_lulesh_domain_mock.cpp with opt -O3
+        LOG_DEBUG("Continue with " << *store_inst)
         continue;
       }
       if (anchor_path.value()) {
@@ -96,6 +112,17 @@ llvm::SmallVector<ValuePath, 4> type_for_heap_call(const llvm::CallBase* call) {
       }
       continue;
     }
+
+    if (auto* store_inst = dyn_cast_or_null<MemIntrinsic>(anchor_path.value().value_or(nullptr))) {
+      value_traversal.traverse_custom(anchor_path.value().value(), malloc_anchor_backtrack, should_search,
+                                      backtrack_search_dir_fn);
+      for (const auto& backtrack_path : malloc_anchor_backtrack.types_path) {
+        LOG_DEBUG("Found backtrack path for memintrinsic " << backtrack_path)
+        ditype_paths.emplace_back(backtrack_path);
+      }
+      continue;
+    }
+
     ditype_paths.emplace_back(anchor_path);
   }
 
@@ -116,6 +143,17 @@ llvm::SmallVector<ValuePath, 4> path_from_alloca(const llvm::AllocaInst* alloca)
 
   MallocAnchorMatcher malloc_forward_anchor_finder;
   value_traversal.traverse(alloca, malloc_forward_anchor_finder, should_search);
+  return malloc_forward_anchor_finder.anchors;
+}
+
+llvm::SmallVector<ValuePath, 4> path_from_instruction(const llvm::Instruction* inst) {
+  using namespace llvm;
+
+  auto should_search = [&](const ValuePath&) -> bool { return true; };
+  DefUseChain value_traversal;
+
+  MallocAnchorMatcher malloc_forward_anchor_finder;
+  value_traversal.traverse(inst, malloc_forward_anchor_finder, should_search);
   return malloc_forward_anchor_finder.anchors;
 }
 
@@ -174,11 +212,20 @@ auto MallocBacktrackSearch::operator()(const ValuePath& path) -> std::optional<V
       }
       return result;
     }
-      //    case Instruction::Call: {
-      //      LOG_DEBUG("Handle call inst")
-      //      result.push_back(inst);
-      //      return result;
-      //    }
+    case Instruction::Call: {
+      LOG_DEBUG("Handle call inst")
+      if (MemCpyInst::classof(inst)) {
+        result.push_back(inst->getOperand(0));
+      }
+
+      return result;
+    }
+    case Instruction::SExt: {
+      // Used by fortran/07_bounds.f90
+      LOG_DEBUG("Handle SExt inst")
+      result.push_back(llvm::dyn_cast<llvm::SExtInst>(inst)->getOperand(0));
+      return result;
+    }
   }
   return {};
 }
@@ -199,6 +246,9 @@ auto MallocTargetMatcher::operator()(const ValuePath& path) -> decltype(DefUseCh
   // Handle path to alloca -> can extract type
   if (const auto* inst = dyn_cast<Instruction>(value)) {
     if (isa<IntrinsicInst>(inst)) {
+      if (llvm::MemCpyInst::classof(inst)) {
+        return DefUseChain::kContinue;
+      }
       return DefUseChain::kSkip;
     }
     if (isa<AllocaInst>(inst)) {
@@ -256,6 +306,11 @@ auto MallocAnchorMatcher::operator()(const ValuePath& path) -> decltype(DefUseCh
   }
 
   if (llvm::isa<IntrinsicInst>(inst)) {
+    if (const auto memcpy = llvm::dyn_cast<MemIntrinsic>(inst)) {
+      anchors.push_back(path);
+      LOG_DEBUG("Found memintrinsic " << *memcpy)
+      return DefUseChain::kSkip;
+    }
     return DefUseChain::kSkip;
   }
 
@@ -267,6 +322,12 @@ auto MallocAnchorMatcher::operator()(const ValuePath& path) -> decltype(DefUseCh
     case Instruction::Store: {
       const auto* store = cast<StoreInst>(inst);
       if (store->getPointerOperand() != path.start_value()) {
+        for (auto user : store->getPointerOperand()->users()) {
+          if (const auto memcpy = llvm::dyn_cast<MemIntrinsic>(user)) {
+            LOG_DEBUG("Store to target for memintrinsic " << *memcpy)
+            return DefUseChain::kContinue;
+          }
+        }
         anchors.push_back(path);
       } else {
         LOG_DEBUG("Store to allocated object, skipping. " << *store)
@@ -325,6 +386,105 @@ auto MallocAnchorMatcher::operator()(const ValuePath& path) -> decltype(DefUseCh
   }
   return DefUseChain::kContinue;
 }
+
+namespace fortran {
+
+inline std::int64_t get_as_int(llvm::Value* shape) {
+  const auto to_int = [](const llvm::Value* shape) -> std::optional<std::int64_t> {
+    if (shape == nullptr) {
+      return {};
+    }
+    auto* constant_int = llvm::dyn_cast<llvm::ConstantInt>(shape);
+    // assert(constant_int && "Expected llvm::ConstantInt");
+    if (constant_int) {
+      assert(constant_int->getBitWidth() <= 64 && "Value is too wide");
+      const auto type_id = static_cast<std::int64_t>(constant_int->getSExtValue());
+      return {type_id};
+    }
+    return {};
+  };
+
+  const auto int_value = to_int(shape);
+  if (int_value) {
+    return int_value.value();
+  }
+
+  std::optional<std::int64_t> global_value;
+  {
+    DefUseChain value_traversal;
+    MallocBacktrackSearch backtrack_search_dir_fn;
+    value_traversal.traverse_custom(
+        shape,
+        [&](const ValuePath& path) {
+          LOG_DEBUG("Global value for shape: " << **path.value())
+          if (auto global = llvm::dyn_cast<llvm::GlobalVariable>(*path.value())) {
+            const auto int_value = to_int(global->getInitializer());
+
+            if (int_value) {
+              LOG_DEBUG("Global int for shape: " << int_value.value())
+              global_value = int_value;
+            }
+            return DefUseChain::kCancel;
+          }
+          return DefUseChain::kContinue;
+        },
+        [&](const ValuePath&) -> bool { return true; }, backtrack_search_dir_fn);
+  }
+  return global_value.value_or(-1);
+}
+
+std::optional<ShapeData> shape_from_value(const llvm::Value* start) {
+  DefUseChain value_traversal;
+
+  ShapeData data;
+  value_traversal.traverse(
+      start,
+      [&](const ValuePath& path) {
+        if (auto call = llvm::dyn_cast<llvm::CallBase>(*path.value())) {
+          if ((call->getCalledFunction() != nullptr) &&
+              util::starts_with_any_of(call->getCalledFunction()->getName(), "_FortranAAllocatableSetBounds",
+                                       "_FortranAPointerSetBounds")) {
+            // shape = call->getOperand(3);
+            // LOG_DEBUG("Found shape: " << *shape.value())
+            const auto dim = get_as_int(call->getOperand(3));
+            data.shapes.emplace_back(ShapeData::IndexDim{get_as_int(call->getOperand(1)), dim});
+            return DefUseChain::kContinue;
+          }
+        }
+        return DefUseChain::kContinue;
+      },
+      [&](const ValuePath&) -> bool { return true; });
+
+  if (data.shapes.empty()) {
+    return {};
+  }
+  return data;
+}
+
+bool passed_to_fortran_helper(const llvm::Value* start) {
+  DefUseChain value_traversal;
+
+  bool passed{false};
+  value_traversal.traverse(
+      start,
+      [&](const ValuePath& path) {
+        if (auto call = llvm::dyn_cast<llvm::CallBase>(*path.value())) {
+          if (call->getCalledFunction() != nullptr) {
+            auto fn_name = call->getCalledFunction()->getName();
+            if (util::starts_with_any_of(fn_name, "_FortranA") && fn_name != "_FortranAioOutputAscii") {
+              passed = true;
+              return DefUseChain::kCancel;
+            }
+          }
+        }
+        return DefUseChain::kContinue;
+      },
+      [&](const ValuePath&) -> bool { return true; });
+
+  return passed;
+}
+
+}  // namespace fortran
 
 namespace experimental {
 llvm::SmallVector<dataflow::ValuePath, 4> path_from_value(const llvm::Value* start) {

--- a/lib/type/DataflowAnalysis.h
+++ b/lib/type/DataflowAnalysis.h
@@ -5,10 +5,19 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-#ifndef DIMETA_DATAFLOWANALYSIS_H
-#define DIMETA_DATAFLOWANALYSIS_H
+#ifndef LIB_TYPE_DATAFLOWANALYSIS
+#define LIB_TYPE_DATAFLOWANALYSIS
 
 #include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+#include <llvm/IR/Instruction.h>
+#include <optional>
+#include <vector>
+
+namespace dimeta {
+struct ShapeData;
+}
 
 namespace dimeta::dataflow {
 struct ValuePath;
@@ -25,6 +34,12 @@ namespace dimeta::dataflow {
 llvm::SmallVector<dataflow::ValuePath, 4> type_for_heap_call(const llvm::CallBase* call);
 
 llvm::SmallVector<dataflow::ValuePath, 4> path_from_alloca(const llvm::AllocaInst* alloca);
+llvm::SmallVector<dataflow::ValuePath, 4> path_from_instruction(const llvm::Instruction* inst);
+
+namespace fortran {
+std::optional<ShapeData> shape_from_value(const llvm::Value* start);
+bool passed_to_fortran_helper(const llvm::Value* start);
+}  // namespace fortran
 
 namespace experimental {
 llvm::SmallVector<dataflow::ValuePath, 4> path_from_value(const llvm::Value*);
@@ -32,4 +47,4 @@ llvm::SmallVector<dataflow::ValuePath, 4> path_from_value(const llvm::Value*);
 
 }  // namespace dimeta::dataflow
 
-#endif  // DIMETA_DATAFLOWANALYSIS_H
+#endif /* LIB_TYPE_DATAFLOWANALYSIS */

--- a/lib/type/DefUseAnalysis.h
+++ b/lib/type/DefUseAnalysis.h
@@ -5,8 +5,8 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-#ifndef DIMETA_DEFUSEANALYSIS_H
-#define DIMETA_DEFUSEANALYSIS_H
+#ifndef LIB_TYPE_DEFUSEANALYSIS
+#define LIB_TYPE_DEFUSEANALYSIS
 
 #include "Util.h"
 #include "ValuePath.h"
@@ -124,4 +124,4 @@ struct DefUseChain {
 
 }  // namespace dimeta::dataflow
 
-#endif  // DIMETA_DEFUSEANALYSIS_H
+#endif /* LIB_TYPE_DEFUSEANALYSIS */

--- a/lib/type/Dimeta.cpp
+++ b/lib/type/Dimeta.cpp
@@ -10,6 +10,7 @@
 #include "DIFinder.h"
 #include "DIRootType.h"
 #include "DITypeExtractor.h"
+#include "DIUtil.h"
 #include "DataflowAnalysis.h"
 #include "DefUseAnalysis.h"
 #include "DimetaData.h"
@@ -44,6 +45,7 @@
 
 #include <cassert>
 #include <iterator>
+#include <optional>
 #include <string>
 
 namespace llvm {
@@ -56,6 +58,14 @@ class DbgVariableIntrinsic;
 #endif
 
 namespace dimeta {
+
+namespace fortran {
+struct FortranType {
+  llvm::DIType* type{nullptr};
+  std::optional<ShapeData> shape_argument;
+};
+std::optional<FortranType> di_type_for(const llvm::Value* value, const llvm::CallBase* call = nullptr);
+}  // namespace fortran
 
 namespace experimental {
 std::optional<llvm::DIType*> di_type_for(const llvm::Value* value);
@@ -78,7 +88,7 @@ auto final_ditype(std::optional<llvm::DIType*> root_ditype) -> std::pair<std::op
   llvm::DIType* type = *root_ditype;
   while (llvm::isa<llvm::DIDerivedType>(type)) {
     auto ditype = llvm::dyn_cast<llvm::DIDerivedType>(type);
-    if (ditype->getTag() == llvm::dwarf::DW_TAG_pointer_type) {
+    if (di::util::is_pointer(*ditype, false)) {
       ++level;
     }
     // void*-based derived types have basetype=null:
@@ -143,7 +153,20 @@ std::optional<DimetaData> type_for(const llvm::CallBase* call) {
   }
 
   std::optional<llvm::DIType*> extracted_type{};
+  std::optional<ShapeData> shape_type{};
   int pointer_level_offset{0};
+
+  const auto is_fortran_like = mem_ops.isFortranLike(cb_fun->getName());
+  if (is_fortran_like) {
+    LOG_DEBUG("Type for fortran-like " << cb_fun->getName())
+    auto fortran_type = fortran::di_type_for(call->getOperand(0), call);
+    if (fortran_type) {
+      extracted_type = fortran_type->type;
+      if (fortran_type->shape_argument) {
+        shape_type = fortran_type->shape_argument;
+      }
+    }
+  }
 
   const auto is_cuda_like = mem_ops.isCudaLike(cb_fun->getName());
   if (is_cuda_like) {
@@ -185,20 +208,27 @@ std::optional<DimetaData> type_for(const llvm::CallBase* call) {
   }
   auto source_loc                        = difinder::find_location(call);
   const auto [final_type, pointer_level] = final_ditype(extracted_type);
-  const auto meta = DimetaData{DimetaData::MemLoc::kHeap,           {}, extracted_type, final_type, source_loc,
-                               pointer_level + pointer_level_offset};
+  const auto meta =
+      DimetaData{DimetaData::MemLoc::kHeap,           {}, extracted_type, final_type, source_loc, shape_type,
+                 pointer_level + pointer_level_offset};
   return meta;
 }
 
 std::optional<DimetaData> type_for(const llvm::AllocaInst* ai) {
   const auto local_di_var = difinder::find_local_variable(ai);
 
+  const auto passed = dataflow::fortran::passed_to_fortran_helper(ai);
+  if (passed) {
+    LOG_DEBUG("Skip allocation passed to Flang intrinsic")
+    return {};
+  }
+
   if (local_di_var) {
     auto extracted_type                    = local_di_var.value()->getType();
     auto source_loc                        = difinder::find_location(ai);
     const auto [final_type, pointer_level] = final_ditype(extracted_type);
     const auto meta =
-        DimetaData{DimetaData::MemLoc::kStack, local_di_var, extracted_type, final_type, source_loc, pointer_level};
+        DimetaData{DimetaData::MemLoc::kStack, local_di_var, extracted_type, final_type, source_loc, {}, pointer_level};
     return meta;
   }
 
@@ -214,7 +244,7 @@ std::optional<DimetaData> type_for(const llvm::GlobalVariable* gv) {
     auto gv_expr                           = *dbg_info.begin();
     auto gv_type                           = gv_expr->getVariable()->getType();
     const auto [final_type, pointer_level] = final_ditype(gv_type);
-    return DimetaData{DimetaData::MemLoc::kGlobal, gv_expr->getVariable(), gv_type, final_type, {}, pointer_level};
+    return DimetaData{DimetaData::MemLoc::kGlobal, gv_expr->getVariable(), gv_type, final_type, {}, {}, pointer_level};
   }
   return {};
 }
@@ -237,6 +267,21 @@ std::optional<CompileUnitTypeList> compile_unit_types(const llvm::Module* module
   }
   return (list.empty() ? std::optional<CompileUnitTypeList>{} : list);
 }
+
+namespace fortran {
+std::optional<FortranType> di_type_for(const llvm::Value* value, const llvm::CallBase* call) {
+  assert(value != nullptr);
+  auto shape = dataflow::fortran::shape_from_value(value);
+
+  auto paths                = dataflow::experimental::path_from_value(value);
+  const auto ditypes_vector = collect_types(call, paths);
+  if (ditypes_vector.empty()) {
+    return {};
+  }
+
+  return FortranType{*ditypes_vector.begin(), shape};
+}
+}  // namespace fortran
 
 namespace experimental {
 std::optional<llvm::DIType*> di_type_for(const llvm::Value* value) {

--- a/lib/type/Dimeta.h
+++ b/lib/type/Dimeta.h
@@ -27,6 +27,15 @@ class Module;
 
 namespace dimeta {
 
+struct ShapeData {
+  struct IndexDim {
+    std::int64_t index{-1};
+    std::int64_t dim{0};
+    llvm::Value* dim_value{nullptr};
+  };
+  std::vector<IndexDim> shapes;
+};
+
 using DimetaDIVariable = std::variant<llvm::DILocalVariable*, llvm::DIGlobalVariable*>;
 
 struct DimetaData {
@@ -36,6 +45,7 @@ struct DimetaData {
   std::optional<llvm::DIType*> entry_type{};       // determined to be the allocation including "pointer" DITypes
   std::optional<llvm::DIType*> base_type{};        // The base type (int, struct X...) of the allocated memory
   std::optional<llvm::DILocation*> di_location{};  // Loc of call (malloc etc.)/alloca. Not set for global
+  std::optional<ShapeData> shape_descriptor{};     // For Fortran: the shape of the array
   int pointer_level{0};                            // e.g., 1 -> int*, 2 -> int**, etc.
 };
 

--- a/lib/type/DimetaData.h
+++ b/lib/type/DimetaData.h
@@ -82,6 +82,7 @@ struct FundamentalType {
     kUTFChar      = 1 << 10,
     kComplex      = 1 << 11,
     kFunctionPtr  = 1 << 12,
+    kString       = 1 << 13,
     kSignedChar   = kChar | kSigned,
     kUnsignedChar = kChar | kUnsigned,
     kSignedInt    = kInt | kSigned,

--- a/lib/type/DimetaIO.cpp
+++ b/lib/type/DimetaIO.cpp
@@ -144,6 +144,7 @@ struct llvm::yaml::ScalarEnumerationTraits<dimeta::FundamentalType::Encoding> {
     io.enumCase(value, "utf_char", dimeta::FundamentalType::Encoding::kUTFChar);
     io.enumCase(value, "complex", dimeta::FundamentalType::Encoding::kComplex);
     io.enumCase(value, "function_ptr", dimeta::FundamentalType::Encoding::kFunctionPtr);
+    io.enumCase(value, "string", dimeta::FundamentalType::Encoding::kString);
   }
 };
 

--- a/lib/type/DimetaParse.cpp
+++ b/lib/type/DimetaParse.cpp
@@ -199,6 +199,9 @@ QualifiedFundamental make_qualified_fundamental(const diparser::state::MetaData&
         // sizeof std::nullptr == sizeof void*
         size =
             meta_.member_size > 0 ? meta_.member_size : (meta_.derived_size > 0 ? meta_.derived_size : sizeof(void*));
+      } else if (encoding == FundamentalType::Encoding::kString) {
+        // TODO: fortran, each character is 1 byte of storage (?)
+        size = 1;
       }
     }
     return size;
@@ -273,6 +276,13 @@ class DITypeParser final : public diparser::DIParseEvents {
     const auto* derived_type = llvm::dyn_cast<llvm::DIDerivedType>(meta_.type);
     assert(derived_type != nullptr && "Type void* should be a derived type");
     emplace_fundamental(meta_, "void", FundamentalType::Encoding::kVoid);
+  }
+
+  void make_string(const diparser::state::MetaData& meta_) override {
+    const auto* string_type = llvm::dyn_cast<llvm::DIStringType>(meta_.type);
+    assert(string_type != nullptr && "Type should be a string type");
+    auto name = string_type->getName();
+    emplace_fundamental(meta_, name.empty() ? "character" : name, FundamentalType::Encoding::kString);
   }
 
   void make_vtable(const diparser::state::MetaData& meta_) override {

--- a/lib/type/GEP.cpp
+++ b/lib/type/GEP.cpp
@@ -7,6 +7,7 @@
 
 #include "GEP.h"
 
+#include "DIFortranTypeExtractor.h"
 #include "DIUtil.h"
 #include "support/Logger.h"
 
@@ -55,6 +56,7 @@ struct GepIndices {
   llvm::SmallVector<uint64_t, 4> indices_;
   bool skipped{false};
   bool is_byte_access{false};
+  bool dynamic_access{false};
   using Iter = llvm::SmallVector<uint64_t, 4>::const_iterator;
 
   llvm::iterator_range<Iter> indices() const {
@@ -109,6 +111,11 @@ GepIndices GepIndices::create(const llvm::GEPOperator* inst, bool skip_first) {
     // gep_ind.indices_.push_back(0);
   }
 
+  if (gep_ind.size() == 0 && !inst->indices().empty()) {
+    LOG_DEBUG("Found dynamic GEP access index")
+    gep_ind.dynamic_access = true;
+  }
+
   return gep_ind;
 }
 
@@ -160,7 +167,7 @@ auto find_non_derived_type_unless(llvm::DIType* root, UnlessFn&& unless) {
 
 inline bool is_ebo_inherited_composite(llvm::DINode* dinode) {
   if (auto* derived = llvm::dyn_cast<llvm::DIDerivedType>(dinode)) {
-    if (derived->getTag() != llvm::dwarf::DW_TAG_inheritance) {
+    if (!di::util::is_inheritance(*derived)) {
       return false;
     }
 
@@ -258,8 +265,10 @@ GepIndexToType iterate_gep_index(llvm::DICompositeType* composite_type, const Ge
 
     if (!llvm::isa<llvm::DIDerivedType>(element)) {
       LOG_DEBUG("Index shows to non-derived type: " << log::ditype_str(element))
-      // TODO, if only one index, and this triggers, go first element all the way down?
-      // maybe also check for class type (not structs etc.)
+      if (di::util::is_array(*element)) {
+        LOG_DEBUG("Indexing into array, returning base type")
+        return GepIndexToType{composite_type->getBaseType()};
+      }
     }
 
     while (gep_index < elements.size() && is_static_member(element)) {
@@ -275,15 +284,14 @@ GepIndexToType iterate_gep_index(llvm::DICompositeType* composite_type, const Ge
       LOG_DEBUG("Looking at " << log::ditype_str(member_type))
 
       if (auto* composite_member_type = llvm::dyn_cast<llvm::DICompositeType>(member_type)) {
-        if (composite_member_type->getTag() == llvm::dwarf::DW_TAG_class_type ||
-            composite_member_type->getTag() == llvm::dwarf::DW_TAG_structure_type) {
+        if (di::util::is_struct_or_class(*composite_member_type)) {
           // maybe need to recurse into!
           if (has_next_gep_idx(enum_index.index())) {
             composite_type = composite_member_type;
             continue;
           }
         }
-        if (composite_member_type->getTag() == llvm::dwarf::DW_TAG_array_type) {
+        if (di::util::is_array(*composite_member_type)) {
           if (has_next_gep_idx(enum_index.index())) {
             LOG_DEBUG("Found array that is indexed with next index")
             // At end of gep instruction, return basetype:
@@ -306,6 +314,13 @@ GepIndexToType resolve_gep_index_to_type(llvm::DICompositeType* composite_type, 
   if (gep_indices.empty()) {
     // this triggers for composite (-array) access without constant index, see "heap_milc_struct_mock.c":
     LOG_DEBUG("Gep indices empty")
+    if (gep_indices.dynamic_access) {
+      // Test fortran 16_...f90, allocation "ALLOCATE(chunk%tiles(t)%field%density ...)":
+      if (di::util::is_array(*composite_type)) {
+        LOG_DEBUG("Assuming array-like access")
+        return GepIndexToType{composite_type->getBaseType()};
+      }
+    }
     return GepIndexToType{composite_type};
   }
 
@@ -428,12 +443,17 @@ GepIndexToType extract_gep_dereferenced_type(llvm::DIType* root, const llvm::GEP
     return GepIndexToType{root};
   }
 
-  auto* const derived_root = llvm::dyn_cast<DIDerivedType>(root);
-  const bool is_pointer_target =
+  const auto* derived_root = llvm::dyn_cast<DIDerivedType>(root);
+  const bool is_derived_root_pointer_type =
+      (derived_root != nullptr) && derived_root->getTag() == dwarf::DW_TAG_pointer_type;
+  const bool is_derived_root_base_pointer =
       (derived_root != nullptr) && derived_root->getBaseType()->getTag() == dwarf::DW_TAG_pointer_type;
-  // TODO: This check seems like a bad idea but I'm not really sure how to do it properly, I reckon we need *some*
-  //       heuristic to detect "fake-array" types though (e.g. gep/array_composite_s.c)
-  if (util::is_byte_indexing(&inst) && (!composite_type || is_pointer_target)) {
+
+  const bool byte_indexing = util::is_byte_indexing(&inst);
+
+  // Handle byte-indexed GEPs that might not target a composite type directly.
+  // This early exit prevents further composite type assertions if not applicable.
+  if (byte_indexing && (!composite_type || is_derived_root_base_pointer)) {
     LOG_DEBUG("Gep with byte offset to pointer-like : " << log::ditype_str(root))
     return GepIndexToType{root};
   }
@@ -442,17 +462,38 @@ GepIndexToType extract_gep_dereferenced_type(llvm::DIType* root, const llvm::GEP
 
   if (composite_type->isForwardDecl()) {
     LOG_DEBUG("Trying to resolve forward-declared composite type " << log::ditype_str(composite_type))
-    return try_resolve_inlined_operator(&inst).value_or(GepIndexToType{root});
+    if (auto resolved = try_resolve_inlined_operator(&inst)) {
+      return resolved.value();
+    }
+    return GepIndexToType{root};
   }
 
   LOG_DEBUG("Gep to DI composite: " << log::ditype_str(composite_type))
-  bool skip_first{!util::is_first_non_zero_indexing(&inst)};
-  if (util::is_byte_indexing(&inst)) {
+
+  // Should skip GEP index? Default: skip the first index if it's a zero-index
+  bool skip_first               = !util::is_first_non_zero_indexing(&inst);
+  const bool single_index       = inst.getNumIndices() == 1;
+  const bool fortran_descriptor = fortran::is_fortran_descriptor(inst.getSourceElementType());
+
+  if (single_index && !fortran_descriptor) {
+    LOG_DEBUG("Single index GEP on non-descriptor, assuming array indexing (no skip)")
+    skip_first = false;
+  }
+  //  If it's a byte-indexed GEP, the first index is a meaningful offset:
+  if (byte_indexing) {
     LOG_DEBUG("Access based on i8 ptr, assuming byte offsetting into composite member")
-    skip_first = false;  // We do not skip over byte index values (likely != 0)
+    skip_first = false;
   }
 
-  auto accessed_ditype = resolve_gep_index_to_type(composite_type, GepIndices::create(&inst, skip_first));
+  auto gep_indices = GepIndices::create(&inst, skip_first);
+
+  // This may be a direct array-like access to the base type of a pointer.
+  if (!byte_indexing && !skip_first && single_index && is_derived_root_pointer_type) {
+    LOG_DEBUG("Return base type, array-like access " << log::ditype_str(derived_root->getBaseType()))
+    return GepIndexToType{derived_root->getBaseType()};
+  }
+
+  auto accessed_ditype = resolve_gep_index_to_type(composite_type, gep_indices);
 
   return accessed_ditype;
 }

--- a/lib/type/MemoryOps.h
+++ b/lib/type/MemoryOps.h
@@ -17,13 +17,14 @@
 namespace dimeta::memory {
 
 enum class MemOpKind : uint8_t {
-  kNewLike          = 1 << 0,  // allocates, never null
-  kMallocLike       = 1 << 1,  // allocates, maybe null
-  kAlignedAllocLike = 1 << 2,  // allocates aligned, maybe null
-  kCallocLike       = 1 << 3,  // allocates zeroed
-  kReallocLike      = 1 << 4,  // re-allocated (existing) memory
-  kNewCppLike       = ((1 << 5) | kNewLike),
-  kCudaMallocLike   = 1 << 6,
+  kNewLike           = 1 << 0,  // allocates, never null
+  kMallocLike        = 1 << 1,  // allocates, maybe null
+  kAlignedAllocLike  = 1 << 2,  // allocates aligned, maybe null
+  kCallocLike        = 1 << 3,  // allocates zeroed
+  kReallocLike       = 1 << 4,  // re-allocated (existing) memory
+  kNewCppLike        = ((1 << 5) | kNewLike),
+  kCudaMallocLike    = 1 << 6,
+  kFortranMallocLike = 1 << 7,
 };
 
 namespace detail {
@@ -65,6 +66,15 @@ struct MemOps {
     return static_cast<bool>(kind);
   }
 
+  [[nodiscard]] inline bool isFortranLike(llvm::StringRef function) const {
+    auto kind = allocKind(function);
+    if (!kind) {
+      return false;
+    }
+    const auto value = kind.value();
+    return detail::has_value(value, MemOpKind::kFortranMallocLike);
+  }
+
  private:
   const llvm::StringMap<MemOpKind> alloc_map_{
       {"malloc", MemOpKind::kMallocLike},
@@ -97,6 +107,8 @@ struct MemOps {
       {"cudaMallocManaged", MemOpKind::kCudaMallocLike},
       {"cudaMallocFromPoolAsync", MemOpKind::kCudaMallocLike},
       {"cudaMallocAsync", MemOpKind::kCudaMallocLike},
+      {"_FortranAAllocatableAllocate", MemOpKind::kFortranMallocLike},
+      {"_FortranAPointerAllocate", MemOpKind::kFortranMallocLike},
 
   };
 };

--- a/lib/type/SourceLocType.cpp
+++ b/lib/type/SourceLocType.cpp
@@ -13,7 +13,10 @@
 
 #include "llvm/IR/DebugInfoMetadata.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/IR/Value.h>
 #include <optional>
 
 namespace dimeta {
@@ -97,6 +100,19 @@ void reset_pointer_qualifier(Type& type, int ptr_level) {
              type);
 }
 
+template <typename Type>
+void reset_shape_qualifier(Type& type, const ShapeData& shape) {
+  const auto add_shape = [&](auto& f) {
+    f.array_size.clear();
+    for (auto index : shape.shapes) {
+      f.array_size.push_back(index.dim);
+    }
+  };
+  std::visit(overload{[&](dimeta::QualifiedFundamental& f) -> void { add_shape(f); },
+                      [&](dimeta::QualifiedCompound& q) -> void { add_shape(q); }},
+             type);
+}
+
 }  // namespace detail
 
 std::optional<LocatedType> located_type_for(const DimetaData& type_data) {
@@ -127,6 +143,11 @@ std::optional<LocatedType> located_type_for(const DimetaData& type_data) {
   }
 
   detail::reset_pointer_qualifier(dimeta_result->type_, type_data.pointer_level);
+  // Fortran:
+  if (type_data.shape_descriptor) {
+    LOG_DEBUG("Reset shape of array")
+    detail::reset_shape_qualifier(dimeta_result->type_, type_data.shape_descriptor.value());
+  }
   return LocatedType{dimeta_result->type_, loc.value()};
 }
 

--- a/lib/type/ValuePath.h
+++ b/lib/type/ValuePath.h
@@ -5,8 +5,8 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-#ifndef DIMETA_VALUEPATH_H
-#define DIMETA_VALUEPATH_H
+#ifndef LIB_TYPE_VALUEPATH
+#define LIB_TYPE_VALUEPATH
 
 #include "Util.h"
 
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/IR/InstrTypes.h>
 #include <optional>
 
@@ -32,6 +33,10 @@ struct ValuePath {
   ValuePath() = default;
 
   explicit ValuePath(const llvm::Value* start) : path_to_value(1, start) {
+  }
+
+  bool contains(const llvm::Value* value) const {
+    return llvm::is_contained(path_to_value, value);
   }
 
   [[nodiscard]] inline bool empty() const {
@@ -124,6 +129,18 @@ inline llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const ValuePath& pat
 }
 
 struct CallValuePath final {
+  CallValuePath(const llvm::CallBase* call_, const ValuePath path_) {
+    if (call_ != nullptr) {
+      call = call_;
+    }
+    path = std::move(path_);
+  }
+  CallValuePath(std::optional<const llvm::CallBase*> call_, const ValuePath path_) {
+    if (call_) {
+      call = std::move(call_);
+    }
+    path = std::move(path_);
+  }
   // The "call" is the initial call the ValuePath is constructed on
   // may be none if RootType calculates the root type based on an alloca
   std::optional<const llvm::CallBase*> call;
@@ -132,4 +149,4 @@ struct CallValuePath final {
 
 }  // namespace dimeta::dataflow
 
-#endif
+#endif /* LIB_TYPE_VALUEPATH */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 dimeta_find_llvm_progs(DIMETA_LIT_EXEC
   "llvm-lit;lit;lit.py"
-  HINTS ${LLVM_EXTERNAL_LIT_DIR} /usr/lib/llvm-${LLVM_VERSION_MAJOR} /usr/lib/llvm /usr/bin /usr/local/bin /opt/local/bin
+  HINTS ${LLVM_EXTERNAL_LIT_DIR} /usr/lib/llvm-${LLVM_VERSION_MAJOR}/build/utils/lit/ /usr/bin /usr/local/bin /opt/local/bin
   ABORT_IF_MISSING
 )
 
@@ -30,11 +30,12 @@ function(configure_dimeta_lit_site_cfg input output)
   set(DIMETA_PASS_DIR ${DIMETA_LIBRARY_DIR}/pass)
   set(DIMETA_TEST_PASS_DIR ${CMAKE_CURRENT_BINARY_DIR}/verifier)
   
-  set(DIMETA_SCRIPT_DIR ${CMAKE_BINARY_DIR}/scripts)
+  set(DIMETA_SCRIPT_DIR ${CMAKE_BINARY_DIR}/script)
 
   pythonize_bool(DIMETA_USE_HEAPALLOCSITE DIMETA_HEAPALLOCSITE)
   pythonize_bool(DIMETA_USE_TBAA DIMETA_TBAA)
-
+  pythonize_bool(DIMETA_ENABLE_FLANG DIMETA_WITH_FLANG)
+  
   if(${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL "13")
     #set(DIMETA_OPT_ARGS "-enable-new-pm=0")
   endif()
@@ -109,6 +110,7 @@ set(DIMETA_SUITES
   pass/inheritance
   pass/call
   pass/cuda
+  pass/fortran
 )
 
 include(ProcessorCount)
@@ -133,32 +135,45 @@ dimeta_target_format(
 )
 
 if(DIMETA_TEST_CONFIGURE_IDE)
-  function(add_test_target_ide target header sources compile_std linker_language)
-    if(NOT sources)
+  function(add_test_target_ide ARG_TARGET)
+    cmake_parse_arguments(ARG "" "COMPILE_STD;LINKER_LANGUAGE" "HEADER;SOURCES" ${ARGN})
+
+    if(NOT ARG_SOURCES)
       return()
     endif()
 
-    add_executable(${target} EXCLUDE_FROM_ALL ${header} ${sources})
+    add_executable(${ARG_TARGET} EXCLUDE_FROM_ALL ${ARG_HEADER} ${ARG_SOURCES})
 
     target_include_directories(
-      ${target} PRIVATE ${PROJECT_SOURCE_DIR}/lib/pass
+      ${ARG_TARGET} PRIVATE ${PROJECT_SOURCE_DIR}/lib/pass
                         ${PROJECT_SOURCE_DIR}/lib
                         ${PROJECT_SOURCE_DIR}
     )
-    target_compile_features(${target} PUBLIC ${compile_std})
-    set_target_properties(${target} PROPERTIES LINKER_LANGUAGE ${linker_language})
+    if(ARG_COMPILE_STD)
+      target_compile_features(${ARG_TARGET} PUBLIC ${ARG_COMPILE_STD})
+    endif()
+    set_target_properties(${ARG_TARGET} PROPERTIES LINKER_LANGUAGE ${ARG_LINKER_LANGUAGE})
   endfunction()
 
   file(GLOB_RECURSE DIMETA_CXX_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pass/*.cpp)
   file(GLOB_RECURSE DIMETA_CC_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pass/*.c)
   file(GLOB_RECURSE DIMETA_HEADER_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pass/*.h)
+  file(GLOB_RECURSE DIMETA_FORTRAN_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pass/*.f90)
 
   add_test_target_ide(dimeta_cxx_test_objects
-    "${DIMETA_HEADER_TESTS}" "${DIMETA_CXX_TESTS}"
-    cxx_std_17 CXX
+    HEADER "${DIMETA_HEADER_TESTS}"
+    SOURCES "${DIMETA_CXX_TESTS}"
+    COMPILE_STD cxx_std_17
+    LINKER_LANGUAGE CXX
   )
   add_test_target_ide(dimeta_cc_test_objects
-    "${DIMETA_HEADER_TESTS}" "${DIMETA_CC_TESTS}"
-    c_std_99 C
+    HEADER "${DIMETA_HEADER_TESTS}"
+    SOURCES "${DIMETA_CC_TESTS}"
+    COMPILE_STD c_std_99
+    LINKER_LANGUAGE C
   )
+  # add_test_target_ide(dimeta_fortran_test_objects
+  #   SOURCES "${DIMETA_FORTRAN_TESTS}"
+  #   LINKER_LANGUAGE Fortran
+  # )
 endif()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -17,22 +17,20 @@ if not loaded_site_cfg:
     raise SystemExit
 
 config.test_format = lit.formats.ShTest(execute_external=True)
-config.suffixes = ['.c','.cpp', '.ll']
+config.suffixes = ['.c','.cpp', '.ll', '.f90']
 config.excludes = ['Inputs', 'verifier']
 
 dimeta_lib_dir    = getattr(config, 'dimeta_lib_dir', None)
-dimeta_pass_dir   = getattr(config, 'dimeta_pass_dir', None)
 dimeta_test_pass_dir   = getattr(config, 'dimeta_test_pass_dir', None)
-dimeta_pass_name  = getattr(config, 'dimeta_pass', None)
 dimeta_test_pass_name  = getattr(config, 'dimeta_test_pass', None)
 dimeta_runtime_dir= getattr(config, 'dimeta_runtime_dir', None)
 dimeta_script_dir = getattr(config, 'dimeta_script_dir', None)
 
 dimeta_std_args = 'dimeta'
 dimeta_test_std_args = 'dimeta-test'
-dimeta_pass     = '{}/{}'.format(dimeta_pass_dir, dimeta_pass_name)
 dimeta_test_pass     = '{}/{}'.format(dimeta_test_pass_dir, dimeta_test_pass_name)
 to_llvm_args    = '-O1 -g -Xclang -disable-llvm-passes -S -emit-llvm -o -'
+to_llvm_flang_args    = '-g -S -emit-llvm -o -'
 
 clang_cpp   = getattr(config, 'clang_cpp', "clang++")
 clang_cc    = getattr(config, 'clang', "clang")
@@ -57,6 +55,10 @@ if config.llvm_version < 14:
 if config.llvm_version > 14:
   config.available_features.add('hasopaque')
 
+if config.with_flang:
+  flang = getattr(config, 'flang', "flang")
+  config.available_features.add('hasflang')
+
 config.available_features.add('llvm-{}'.format(config.llvm_version))
 
 config.available_features.add('{}'.format(config.llvm_version))
@@ -65,16 +67,14 @@ config.available_features.add('{}'.format(config.llvm_version))
 
 config.substitutions.append(('%clang-cpp', clang_cpp))
 config.substitutions.append(('%clang-cc', clang_cc))
+if config.with_flang:
+  config.substitutions.append(('%flang', flang))
 config.substitutions.append(('%opt', opt))
 config.substitutions.append(('%filecheck', filecheck))
 
 config.substitutions.append(('%lib_dir', dimeta_lib_dir))
-config.substitutions.append(('%pass_dir', dimeta_pass_dir))
 if dimeta_runtime_dir is not None:
   config.substitutions.append(('%runtime_dir', dimeta_runtime_dir))
-
-config.substitutions.append(('%pass_name', dimeta_pass_name))
-config.substitutions.append(('%pass_plugin', dimeta_pass))
 
 config.substitutions.append(('%arg_std', dimeta_std_args))
 
@@ -86,6 +86,10 @@ else:
 
 config.substitutions.append(('%c-to-llvm', '{} {}'.format(clang_cc, to_llvm_args)))
 config.substitutions.append(('%cpp-to-llvm', '{} {}'.format(clang_cpp, to_llvm_args)))
+if config.with_flang:
+  config.substitutions.append(('%fortran-to-llvm', '{} {}'.format(flang, to_llvm_flang_args)))
+else:
+  config.substitutions.append(('%fortran-to-llvm', ''))
 
 if dimeta_script_dir is not None:
   config.substitutions.append(('%script_dir', dimeta_script_dir))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -5,6 +5,7 @@ import sys
 # LLVM toolchain:
 config.clang_cpp = "@DIMETA_CLANGCXX_EXEC@"
 config.clang = "@DIMETA_CLANG_EXEC@"
+config.flang = "@DIMETA_FLANG_EXEC@"
 config.opt = "@DIMETA_OPT_SHIM@"
 config.opt_args = "@DIMETA_OPT_ARGS@"
 config.llc = "@DIMETA_LLC_EXEC@"
@@ -12,7 +13,6 @@ config.filecheck = "@DIMETA_FILECHECK_EXEC@"
 
 # Project related:
 config.dimeta_lib_dir = "@DIMETA_LIBRARY_DIR@"
-config.dimeta_pass_dir = "@DIMETA_PASS_DIR@"
 config.dimeta_test_pass_dir = "@DIMETA_TEST_PASS_DIR@"
 
 config.dimeta_script_dir = "@DIMETA_SCRIPT_DIR@"
@@ -22,6 +22,7 @@ config.heapallocsite = @DIMETA_HEAPALLOCSITE@
 config.tbaa = @DIMETA_TBAA@
 
 config.llvm_version = @LLVM_VERSION_MAJOR@
+config.with_flang = @DIMETA_WITH_FLANG@
 
 # Let the main config do the real work.
 config.loaded_site_config = True

--- a/test/pass/c/complex_nested_allocate.c
+++ b/test/pass/c/complex_nested_allocate.c
@@ -1,0 +1,49 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+// From Fortran test 17
+#include <stdlib.h>
+
+typedef struct {
+  double *energy0, *energy1, *u;
+  double *cellx, *celly, *vertexx, *vertexy;
+  int x_min, x_max, y_min, y_max;
+} field_type;
+
+typedef struct {
+  field_type field;
+} tile_type;
+
+typedef struct {
+  tile_type* tiles;
+  int halo_exchange_depth;
+} chunk_type;
+
+void do_alloc(int t, chunk_type* chunk) {
+  chunk->tiles[t].field.energy0 = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  chunk->tiles[t].field.energy1 = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  chunk->tiles[t].field.u = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  chunk->tiles[t].field.cellx = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  chunk->tiles[t].field.celly = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  chunk->tiles[t].field.vertexx = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  chunk->tiles[t].field.vertexy = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+}

--- a/test/pass/c/full_nested_allocate.c
+++ b/test/pass/c/full_nested_allocate.c
@@ -1,0 +1,80 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+// From Fortran test 18
+#include <stdlib.h>
+
+typedef struct {
+  float *energy0, *energy1, *u;
+  double *cellx, *celly, *vertexx, *vertexy;
+  int x_min, x_max, y_min, y_max;
+} field_type;
+
+typedef struct {
+  field_type field;
+  int left, right, bottom, top;
+  int x_cells, y_cells;
+  int tile_neighbours[4];
+  int tile_coords[2];
+} tile_type;
+
+typedef struct {
+  int task;
+  int chunk_x_min, chunk_y_min, chunk_x_max, chunk_y_max;
+  int x_cells, y_cells;
+  int left, right, bottom, top;
+  int chunk_neighbours[4];
+  double *left_rcv_buffer, *right_rcv_buffer, *bottom_rcv_buffer, *top_rcv_buffer;
+  double *left_snd_buffer, *right_snd_buffer, *bottom_snd_buffer, *top_snd_buffer;
+  tile_type* tiles;
+  int tile_dims[2];
+  int sub_tile_dims[2];
+  int halo_exchange_depth;
+} chunk_type;
+
+void do_alloc(int t_idx, chunk_type* chunk) {
+  // Allocate the tiles array if not already allocated
+  if (!chunk->tiles) {
+    chunk->tiles = (tile_type*)malloc(sizeof(tile_type) * (t_idx + 1));  // Ensure size for t_idx
+  }
+  // Initialize some values for bounds, similar to Fortran test
+  chunk->halo_exchange_depth      = 1;
+  chunk->tiles[t_idx].field.x_min = 0;
+  chunk->tiles[t_idx].field.x_max = 9;
+  chunk->tiles[t_idx].field.y_min = 0;
+  chunk->tiles[t_idx].field.y_max = 9;
+
+  // ALLOCATE(chunk%tiles(t)%field%energy0 ...)
+  chunk->tiles[t_idx].field.energy0 = (float*)malloc(sizeof(float) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: float, Extent: 4, Encoding: float }
+
+  // ALLOCATE(chunk%tiles(t)%field%energy1 ...)
+  chunk->tiles[t_idx].field.energy1 = (float*)malloc(sizeof(float) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: float, Extent: 4, Encoding: float }
+
+  // ALLOCATE(chunk%tiles(t)%field%u ...)
+  chunk->tiles[t_idx].field.u = (float*)malloc(sizeof(float) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: float, Extent: 4, Encoding: float }
+
+  // ALLOCATE(chunk%tiles(t)%field%cellx ...)
+  chunk->tiles[t_idx].field.cellx = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  // ALLOCATE(chunk%tiles(t)%field%celly ...)
+  chunk->tiles[t_idx].field.celly = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  // ALLOCATE(chunk%tiles(t)%field%vertexx ...)
+  chunk->tiles[t_idx].field.vertexx = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+
+  // ALLOCATE(chunk%tiles(t)%field%vertexy ...)
+  chunk->tiles[t_idx].field.vertexy = (double*)malloc(sizeof(double) * 10);
+  // CHECK: Line:            [[@LINE-1]]
+  // CHECK: Fundamental:     { Name: double, Extent: 8, Encoding: float }
+}

--- a/test/pass/c/heap_nested_allocate.c
+++ b/test/pass/c/heap_nested_allocate.c
@@ -1,0 +1,53 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+#include <stdlib.h>
+
+struct field_type {
+  double* density;
+  int x_min, x_max, y_min, y_max;
+};
+
+typedef struct field_type field_type;
+
+struct tile_type {
+  field_type field;
+  int left, right, bottom, top;
+  int x_cells, y_cells;
+  int tile_neighbours[4];
+  int tile_coords[2];
+};
+
+typedef struct tile_type tile_type;
+
+struct chunk_type {
+  int task;
+  int chunk_x_min, chunk_y_min, chunk_x_max, chunk_y_max;
+  int x_cells, y_cells;
+  int left, right, bottom, top;
+  int chunk_neighbours[4];
+  double *left_rcv_buffer, *right_rcv_buffer, *bottom_rcv_buffer, *top_rcv_buffer;
+  double *left_snd_buffer, *right_snd_buffer, *bottom_snd_buffer, *top_snd_buffer;
+  tile_type* tiles;
+  int tile_dims[2];
+  int sub_tile_dims[2];
+  int halo_exchange_depth;
+};
+
+typedef struct chunk_type chunk_type;
+
+void do_alloc(int t) {
+  chunk_type* chunk = (chunk_type*)malloc(sizeof(chunk_type));
+
+  // CHECK:      Line:            47
+  // CHECK-NEXT: Builtin:         false
+  // CHECK-NEXT: Type:
+  // CHECK-NEXT:   Compound:
+  // CHECK-NEXT:     Name:            tile_type
+  // CHECK-NEXT:     Type:            struct
+  chunk->tiles = (tile_type*)malloc(t * sizeof(tile_type));
+
+  // CHECK:      Line:            52
+  // CHECK:      Fundamental:     { Name: double, Extent: 8, Encoding: float }
+  // CHECK:      Qualifiers:      [ ptr ]
+  chunk->tiles[0].field.density = (double*)malloc(10 * sizeof(double));
+}

--- a/test/pass/c/stack_struct_bitint.c
+++ b/test/pass/c/stack_struct_bitint.c
@@ -21,12 +21,12 @@ void foo() {
 // CHECK-NEXT:   - Name:            bitint8_var
 // CHECK-NEXT:     Builtin:         true
 // CHECK-NEXT:     Type:
-// CHECK-NEXT:       Fundamental:     { Name: _BitInt, Extent: 1, Encoding: signed_int }
+// CHECK-NEXT:       Fundamental:     { Name: {{[']?}}_BitInt{{.*[']?}}, Extent: 1, Encoding: signed_int }
 // CHECK-NEXT:   - Name:            bitint16_var
 // CHECK-NEXT:     Builtin:         true
 // CHECK-NEXT:     Type:
-// CHECK-NEXT:       Fundamental:     { Name: _BitInt, Extent: 2, Encoding: signed_int }
+// CHECK-NEXT:       Fundamental:     { Name: {{[']?}}_BitInt{{.*[']?}}, Extent: 2, Encoding: signed_int }
 // CHECK-NEXT:   - Name:            bitint32_var
 // CHECK-NEXT:     Builtin:         true
 // CHECK-NEXT:     Type:
-// CHECK-NEXT:       Fundamental:     { Name: _BitInt, Extent: 4, Encoding: signed_int }
+// CHECK-NEXT:       Fundamental:     { Name: {{[']?}}_BitInt{{.*[']?}}, Extent: 4, Encoding: signed_int }

--- a/test/pass/cuda/heap_template.ll
+++ b/test/pass/cuda/heap_template.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK:   Function:        'cudaMalloc<float>'
 ; CHECK-NEXT:   Line:            77

--- a/test/pass/cuda/heap_template_no_assign.ll
+++ b/test/pass/cuda/heap_template_no_assign.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ;    Function:        'cudaMalloc<float>'
 ; CHECK:   Line:            684

--- a/test/pass/fortran/01_heap.f90
+++ b/test/pass/fortran/01_heap.f90
@@ -1,0 +1,16 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+FUNCTION foo(n) result(i)
+   INTEGER, INTENT(IN) :: n
+   INTEGER, ALLOCATABLE :: foo_a(:)
+   INTEGER :: i
+   ALLOCATE(foo_a(n))
+END FUNCTION foo
+
+! CHECK: SourceLoc:
+! CHECK:  Line:            9
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT: Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }

--- a/test/pass/fortran/02_heap_double.f90
+++ b/test/pass/fortran/02_heap_double.f90
@@ -1,0 +1,20 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+FUNCTION foo(n)
+   INTEGER, PARAMETER :: DP = KIND(1.0D0)
+   INTEGER, INTENT(IN) :: n
+   REAL(KIND=DP), ALLOCATABLE :: foo(:)
+   INTEGER :: i
+   ALLOCATE(foo(n))
+   DO i = 1, n
+      foo(i) = DBLE(i) * 10.0D0
+   END DO
+END FUNCTION foo
+
+! CHECK:  Line:            11
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }

--- a/test/pass/fortran/02_heap_double.f90
+++ b/test/pass/fortran/02_heap_double.f90
@@ -17,4 +17,4 @@ END FUNCTION foo
 ! CHECK:  Line:            11
 ! CHECK-NEXT: Builtin:         true
 ! CHECK-NEXT: Type:
-! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }

--- a/test/pass/fortran/03_heap_mold.f90
+++ b/test/pass/fortran/03_heap_mold.f90
@@ -1,0 +1,17 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+subroutine scalar_mold_allocation()
+   REAL*8, allocatable :: a(:)
+   ! real :: b
+   allocate(a(102), mold=2.0D0)
+end subroutine
+
+! CHECK:  Line:            9
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Array:           [ 102 ]
+! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/03_heap_mold.f90
+++ b/test/pass/fortran/03_heap_mold.f90
@@ -12,6 +12,6 @@ end subroutine
 ! CHECK:  Line:            9
 ! CHECK-NEXT: Builtin:         true
 ! CHECK-NEXT: Type:
-! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK-NEXT: Array:           [ 102 ]
 ! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/04_heap_mold_dim2.f90
+++ b/test/pass/fortran/04_heap_mold_dim2.f90
@@ -11,6 +11,6 @@ end subroutine
 ! CHECK:  Line:            8
 ! CHECK-NEXT: Builtin:         true
 ! CHECK-NEXT: Type:
-! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK-NEXT: Array:           [ 102, 10 ]
 ! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/04_heap_mold_dim2.f90
+++ b/test/pass/fortran/04_heap_mold_dim2.f90
@@ -1,0 +1,16 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+subroutine scalar_mold_allocation()
+   REAL*8, allocatable :: a(:,:)
+   allocate(a(102, 10), mold=2.0D0)
+end subroutine
+
+! CHECK:  Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK-NEXT: Array:           [ 102, 10 ]
+! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/05_stack_array.f90
+++ b/test/pass/fortran/05_stack_array.f90
@@ -1,0 +1,20 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE use_local_array()
+   IMPLICIT NONE
+   INTEGER, PARAMETER :: SIZE = 7
+   INTEGER :: local_stack_array(SIZE)
+   INTEGER :: i
+   DO i = 1, SIZE
+      local_stack_array(i) = i * 10
+   END DO
+END SUBROUTINE use_local_array
+
+! CHECK:  Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT: Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT: Array:           [ 7 ]
+! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/06_stack_array_dim2.f90
+++ b/test/pass/fortran/06_stack_array_dim2.f90
@@ -1,0 +1,20 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE use_local_array()
+   IMPLICIT NONE
+   INTEGER, PARAMETER :: SIZE = 7
+   INTEGER :: local_stack_array(SIZE,SIZE)
+   INTEGER :: i
+   DO i = 1, SIZE
+      local_stack_array(i,i) = i * 10
+   END DO
+END SUBROUTINE use_local_array
+
+! CHECK:  Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT: Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT: Array:           [ 49 ]
+! CHECK-NEXT: Qualifiers:      [ array ]

--- a/test/pass/fortran/07_bounds.f90
+++ b/test/pass/fortran/07_bounds.f90
@@ -1,0 +1,50 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+MODULE tea_module
+   IMPLICIT NONE
+
+   TYPE :: TileType
+      INTEGER :: x_cells = 10
+      INTEGER :: y_cells = 10
+   END TYPE TileType
+
+   TYPE :: ChunkType
+      INTEGER :: halo_exchange_depth = 0
+      TYPE(TileType), ALLOCATABLE :: tiles(:)
+   END TYPE ChunkType
+
+   TYPE(ChunkType) :: chunk
+   INTEGER :: tiles_per_task = 3
+
+CONTAINS
+
+   SUBROUTINE build_field()
+      IMPLICIT NONE
+      ALLOCATE(chunk%tiles(tiles_per_task))
+   END SUBROUTINE build_field
+
+END MODULE tea_module
+
+! CHECK:   Line:            26
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            tiletype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          8
+! CHECK-NEXT:     Sizes:           [ 4, 4 ]
+! CHECK-NEXT:     Offsets:         [ 0, 4 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            x_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:       - Name:            y_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:           [ 3 ]
+! CHECK-NEXT:   Qualifiers:      [ array ]

--- a/test/pass/fortran/08_bounds_nogep.f90
+++ b/test/pass/fortran/08_bounds_nogep.f90
@@ -1,0 +1,50 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+MODULE tea_module
+   IMPLICIT NONE
+
+   TYPE :: TileType
+      INTEGER :: x_cells = 10
+      INTEGER :: y_cells = 10
+   END TYPE TileType
+
+   TYPE :: ChunkType
+      TYPE(TileType), ALLOCATABLE :: tiles(:)
+      INTEGER :: halo_exchange_depth = 0
+   END TYPE ChunkType
+
+   TYPE(ChunkType) :: chunk
+   INTEGER :: tiles_per_task = 3
+
+CONTAINS
+
+   SUBROUTINE build_field()
+      IMPLICIT NONE
+      ALLOCATE(chunk%tiles(tiles_per_task))
+   END SUBROUTINE build_field
+
+END MODULE tea_module
+
+! CHECK:   Line:            26
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            tiletype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          8
+! CHECK-NEXT:     Sizes:           [ 4, 4 ]
+! CHECK-NEXT:     Offsets:         [ 0, 4 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            x_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:       - Name:            y_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:           [ 3 ]
+! CHECK-NEXT:   Qualifiers:      [ array ]

--- a/test/pass/fortran/09_local_bounds.f90
+++ b/test/pass/fortran/09_local_bounds.f90
@@ -1,0 +1,49 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+MODULE tea_module
+   IMPLICIT NONE
+   TYPE :: TileType
+      INTEGER :: x_cells = 10
+      INTEGER :: y_cells = 10
+   END TYPE TileType
+   TYPE :: ChunkType
+      TYPE(TileType), ALLOCATABLE :: tiles(:)
+      INTEGER :: halo_exchange_depth = 0
+   END TYPE ChunkType
+
+   ! TYPE(ChunkType) :: chunk
+   INTEGER :: tiles_per_task = 3
+
+CONTAINS
+
+   SUBROUTINE build_field()
+      IMPLICIT NONE
+      TYPE(ChunkType) :: local_chunk
+      ALLOCATE(local_chunk%tiles(tiles_per_task))
+   END SUBROUTINE build_field
+
+END MODULE tea_module
+
+! CHECK:   Line:            25
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            tiletype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          8
+! CHECK-NEXT:     Sizes:           [ 4, 4 ]
+! CHECK-NEXT:     Offsets:         [ 0, 4 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            x_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:       - Name:            y_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:           [ 3 ]
+! CHECK-NEXT:   Qualifiers:      [ array ]

--- a/test/pass/fortran/10_local_bounds_alloc_of_alloc.f90
+++ b/test/pass/fortran/10_local_bounds_alloc_of_alloc.f90
@@ -1,0 +1,84 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+!  %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+
+
+MODULE tea_module
+   IMPLICIT NONE
+   TYPE :: TileType
+      INTEGER :: x_cells = 10
+      INTEGER :: y_cells = 10
+   END TYPE TileType
+   TYPE :: ChunkType
+      TYPE(TileType), ALLOCATABLE :: tiles(:)
+      INTEGER :: halo_exchange_depth = 0
+   END TYPE ChunkType
+
+   ! TYPE(ChunkType) :: chunk
+   INTEGER :: tiles_per_task = 3
+
+CONTAINS
+
+   SUBROUTINE build_field()
+      IMPLICIT NONE
+      TYPE(ChunkType), ALLOCATABLE :: local_chunk
+      ALLOCATE(local_chunk)
+      ALLOCATE(local_chunk%tiles(tiles_per_task))
+   END SUBROUTINE build_field
+
+END MODULE tea_module
+
+! CHECK:     Name:            chunktype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          68
+! CHECK-NEXT:     Sizes:           [ 64, 4 ]
+! CHECK-NEXT:     Offsets:         [ 0, 64 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            tiles
+! CHECK-NEXT:         Builtin:         false
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Compound:
+! CHECK-NEXT:             Name:            tiletype
+! CHECK-NEXT:             Type:            struct
+! CHECK-NEXT:             Extent:          8
+! CHECK-NEXT:             Sizes:           [ 4, 4 ]
+! CHECK-NEXT:             Offsets:         [ 0, 4 ]
+! CHECK-NEXT:             Members:
+! CHECK-NEXT:               - Name:            x_cells
+! CHECK-NEXT:                 Builtin:         true
+! CHECK-NEXT:                 Type:
+! CHECK-NEXT:                   Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:               - Name:            y_cells
+! CHECK-NEXT:                 Builtin:         true
+! CHECK-NEXT:                 Type:
+! CHECK-NEXT:                   Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:           Array:           [ 1 ]
+! CHECK-NEXT:           Qualifiers:      [ array ]
+! CHECK-NEXT:       - Name:            halo_exchange_depth
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Qualifiers:      [ ptr ]
+
+! CHECK:   Line:            28
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            tiletype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          8
+! CHECK-NEXT:     Sizes:           [ 4, 4 ]
+! CHECK-NEXT:     Offsets:         [ 0, 4 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            x_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:       - Name:            y_cells
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:           [ 3 ]
+! CHECK-NEXT:   Qualifiers:      [ array ]

--- a/test/pass/fortran/11_double_allocatable.f90
+++ b/test/pass/fortran/11_double_allocatable.f90
@@ -1,0 +1,52 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! : %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+
+program nested_allocation
+   implicit none
+   type :: Mesh
+      integer :: num_nodes
+      integer :: num_elements
+      real, dimension(:,:), allocatable :: coordinates
+      integer, dimension(:,:), allocatable :: connectivity
+   end type Mesh
+
+   type(Mesh), allocatable :: my_mesh
+
+   allocate(my_mesh)
+   my_mesh%num_nodes = 99
+   my_mesh%num_elements = 500
+
+   allocate(my_mesh%coordinates(77, my_mesh%num_nodes))
+   allocate(my_mesh%connectivity(4, my_mesh%num_elements))
+end program nested_allocation
+
+
+! CHECK:      SourceLoc:
+! CHECK:   Line:            18
+! CHECK: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            mesh
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          152
+! CHECK-NEXT:     Sizes:           [ 4, 4, 72, 72 ]
+! CHECK-NEXT:     Offsets:         [ 0, 4, 8, 80 ]
+
+! CHECK:      SourceLoc:
+! CHECK:   Line:             22
+! CHECK-NEXT: Builtin:          true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:      { Name: real, Extent: 4, Encoding: float }
+! CHECK-NEXT:   Array:            [ 1 ]
+! CHECK-NEXT:   Qualifiers:       [ array ]
+
+! CHECK:      SourceLoc:
+! CHECK:   Line:             23
+! CHECK-NEXT: Builtin:          true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:      { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:            [ 1 ]
+! CHECK-NEXT:   Qualifiers:       [ array ]

--- a/test/pass/fortran/12_inheritance.f90
+++ b/test/pass/fortran/12_inheritance.f90
@@ -1,0 +1,37 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+program test_polymorphic_alloc
+   implicit none
+   type :: BaseType
+      integer :: id = 0
+   end type BaseType
+   type, extends(BaseType) :: ExtType
+      real :: extra_value = 0.0
+   end type ExtType
+
+   class(BaseType), allocatable :: test_obj
+   allocate(ExtType :: test_obj)
+   ! deallocate(test_obj)
+end program test_polymorphic_alloc
+
+! Caveat: no debug data for ExtType, only internal descriptor
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            16
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            basetype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          4
+! CHECK-NEXT:     Sizes:           [ 4 ]
+! CHECK-NEXT:     Offsets:         [ 0 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            id
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Qualifiers:      [ ptr ]

--- a/test/pass/fortran/13_inheritance_access.f90
+++ b/test/pass/fortran/13_inheritance_access.f90
@@ -1,0 +1,44 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+program test_polymorphic_alloc
+   implicit none
+   type :: BaseType
+      integer :: id = 0
+   end type BaseType
+   type, extends(BaseType) :: ExtType
+      real :: extra_value = 0.0
+   end type ExtType
+
+   class(BaseType), allocatable :: test_obj
+   allocate(ExtType :: test_obj)
+
+   ! Access and initialize the extended type's member
+   select type (test_obj)
+    type is (ExtType)
+      test_obj%extra_value = 3.14
+   end select
+
+   ! deallocate(test_obj)
+end program test_polymorphic_alloc
+
+! Caveat: no debug data for ExtType, only internal descriptor
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            16
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            basetype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          4
+! CHECK-NEXT:     Sizes:           [ 4 ]
+! CHECK-NEXT:     Offsets:         [ 0 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            id
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Qualifiers:      [ ptr ]

--- a/test/pass/fortran/14_inheritance_source.f90
+++ b/test/pass/fortran/14_inheritance_source.f90
@@ -1,0 +1,42 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+! XFAIL: *
+
+program test_polymorphic_alloc
+   implicit none
+   type :: BaseType
+      integer :: id = 0
+   end type BaseType
+   type, extends(BaseType) :: ExtType
+      real :: extra_value = 0.0
+   end type ExtType
+
+   class(BaseType), allocatable :: test_obj
+
+   ! Allocate and initialize directly using a source expression
+   allocate(test_obj, source=ExtType(id=0, extra_value=3.14))
+
+   ! deallocate(test_obj)
+end program test_polymorphic_alloc
+
+! Caveat: no debug data for ExtType, only internal descriptor
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            20
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            basetype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          4
+! CHECK-NEXT:     Sizes:           [ 4 ]
+! CHECK-NEXT:     Offsets:         [ 0 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            id
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Qualifiers:      [ ptr ]

--- a/test/pass/fortran/15_inheritance_derived.f90
+++ b/test/pass/fortran/15_inheritance_derived.f90
@@ -1,0 +1,52 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+program test_polymorphic_alloc
+   implicit none
+   type :: BaseType
+      integer :: id = 0
+   end type BaseType
+   type, extends(BaseType) :: ExtType
+      real :: extra_value = 0.0
+   end type ExtType
+
+   type(ExtType), allocatable :: test_obj
+   allocate(test_obj)
+   test_obj%id = 1
+   test_obj%extra_value = 3.14
+
+   ! deallocate(test_obj)
+end program test_polymorphic_alloc
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            16
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            exttype
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          8
+! CHECK-NEXT:     Sizes:           [ 4, 4 ]
+! CHECK-NEXT:     Offsets:         [ 0, 4 ]
+! CHECK-NEXT:     Members:
+! CHECK-NEXT:       - Name:            basetype
+! CHECK-NEXT:         Builtin:         false
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Compound:
+! CHECK-NEXT:             Name:            basetype
+! CHECK-NEXT:             Type:            struct
+! CHECK-NEXT:             Extent:          4
+! CHECK-NEXT:             Sizes:           [ 4 ]
+! CHECK-NEXT:             Offsets:         [ 0 ]
+! CHECK-NEXT:             Members:
+! CHECK-NEXT:               - Name:            id
+! CHECK-NEXT:                 Builtin:         true
+! CHECK-NEXT:                 Type:
+! CHECK-NEXT:                   Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:       - Name:            extra_value
+! CHECK-NEXT:         Builtin:         true
+! CHECK-NEXT:         Type:
+! CHECK-NEXT:           Fundamental:     { Name: real, Extent: 4, Encoding: float }
+! CHECK-NEXT:  Qualifiers:      [ ptr ]

--- a/test/pass/fortran/16_nested_allocate.f90
+++ b/test/pass/fortran/16_nested_allocate.f90
@@ -1,0 +1,79 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+MODULE test_mod
+   IMPLICIT NONE
+
+   TYPE field_type
+      REAL(KIND=8), ALLOCATABLE :: density(:,:)
+      INTEGER :: x_min, x_max, y_min, y_max
+   END TYPE field_type
+
+   TYPE tile_type
+      TYPE(field_type):: field
+
+      INTEGER         :: left            &
+         ,right           &
+         ,bottom          &
+         ,top
+
+      INTEGER            :: x_cells              &
+         ,y_cells
+
+      INTEGER         :: tile_neighbours(4)
+      INTEGER         :: tile_coords(2)
+
+   END TYPE tile_type
+
+   TYPE chunk_type
+      INTEGER         :: task   !mpi task
+      INTEGER         :: chunk_x_min  &
+         ,chunk_y_min  &
+         ,chunk_x_max  &
+         ,chunk_y_max
+      INTEGER            :: x_cells              &
+         ,y_cells
+      INTEGER         :: left            &
+         ,right           &
+         ,bottom          &
+         ,top
+      INTEGER         :: chunk_neighbours(4)
+      REAL(KIND=8),ALLOCATABLE:: left_rcv_buffer(:),right_rcv_buffer(:),bottom_rcv_buffer(:),top_rcv_buffer(:)
+      REAL(KIND=8),ALLOCATABLE:: left_snd_buffer(:),right_snd_buffer(:),bottom_snd_buffer(:),top_snd_buffer(:)
+      TYPE(tile_type), DIMENSION(:), ALLOCATABLE :: tiles
+      INTEGER,DIMENSION(2) :: tile_dims
+      INTEGER,DIMENSION(2) :: sub_tile_dims
+      INTEGER :: halo_exchange_depth
+   END TYPE chunk_type
+
+CONTAINS
+
+   SUBROUTINE do_alloc(t)
+      INTEGER, INTENT(IN) :: t
+      TYPE(chunk_type), ALLOCATABLE :: chunk
+      ALLOCATE(chunk)
+      ALLOCATE(chunk%tiles(t))
+      ! Allocated type: REAL(KIND=8), DIMENSION(:,:)
+      ALLOCATE(chunk%tiles(t)%field%density &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+   END SUBROUTINE do_alloc
+
+END MODULE test_mod
+
+! CHECK:      Line:            57
+! CHECK-NEXT: Builtin:         false
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Compound:
+! CHECK-NEXT:     Name:            tile_type
+! CHECK-NEXT:     Type:            struct
+! CHECK-NEXT:     Extent:          136
+! CHECK-NEXT:     Sizes:           [ 88, 4, 4, 4, 4, 4, 4, 16, 8 ]
+
+! CHECK: Line:            59
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/16_nested_allocate.f90
+++ b/test/pass/fortran/16_nested_allocate.f90
@@ -1,4 +1,4 @@
-! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %apply-verifier | %filecheck %s
 ! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
 
 ! REQUIRES: hasflang
@@ -75,5 +75,5 @@ END MODULE test_mod
 ! CHECK-NEXT:     Sizes:           [ 88, 4, 4, 4, 4, 4, 4, 16, 8 ]
 
 ! CHECK: Line:            59
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/17_complex_nested_allocate.f90
+++ b/test/pass/fortran/17_complex_nested_allocate.f90
@@ -54,29 +54,29 @@ CONTAINS
 END MODULE test_mod
 
 ! CHECK: Line:            29
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            35
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            41
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            47
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            48
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            49
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            50
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/17_complex_nested_allocate.f90
+++ b/test/pass/fortran/17_complex_nested_allocate.f90
@@ -1,0 +1,82 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+! REQUIRES: hasflang
+
+MODULE test_mod
+   IMPLICIT NONE
+
+   TYPE field_type
+      REAL(KIND=8), ALLOCATABLE :: energy0(:,:), energy1(:,:), u(:,:)
+      REAL(KIND=8), ALLOCATABLE :: cellx(:), celly(:), vertexx(:), vertexy(:)
+      INTEGER :: x_min, x_max, y_min, y_max
+   END TYPE field_type
+
+   TYPE tile_type
+      TYPE(field_type):: field
+   END TYPE tile_type
+
+   TYPE chunk_type
+      TYPE(tile_type), DIMENSION(:), ALLOCATABLE :: tiles
+      INTEGER :: halo_exchange_depth
+   END TYPE chunk_type
+
+CONTAINS
+   SUBROUTINE do_alloc(t, chunk)
+      INTEGER, INTENT(IN) :: t
+      TYPE(chunk_type), INTENT(INOUT) :: chunk
+
+      ! ALLOCATE(chunk%tiles(t))
+      ALLOCATE(chunk%tiles(t)%field%energy0 &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+
+      ALLOCATE(chunk%tiles(t)%field%energy1 &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+
+      ALLOCATE(chunk%tiles(t)%field%u       &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+
+      ALLOCATE(chunk%tiles(t)%field%cellx   (chunk%tiles(t)%field%x_min-2:chunk%tiles(t)%field%x_max+2))
+      ALLOCATE(chunk%tiles(t)%field%celly   (chunk%tiles(t)%field%y_min-2:chunk%tiles(t)%field%y_max+2))
+      ALLOCATE(chunk%tiles(t)%field%vertexx (chunk%tiles(t)%field%x_min-2:chunk%tiles(t)%field%x_max+3))
+      ALLOCATE(chunk%tiles(t)%field%vertexy (chunk%tiles(t)%field%y_min-2:chunk%tiles(t)%field%y_max+3))
+
+   END SUBROUTINE do_alloc
+
+END MODULE test_mod
+
+! CHECK: Line:            29
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            35
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            41
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            47
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            48
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            49
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            50
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/18_full_nested_allocate.f90
+++ b/test/pass/fortran/18_full_nested_allocate.f90
@@ -1,0 +1,110 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+! REQUIRES: hasflang
+
+MODULE test_mod
+   IMPLICIT NONE
+
+   TYPE field_type
+      REAL(KIND=4), ALLOCATABLE :: energy0(:,:), energy1(:,:), u(:,:)
+      REAL(KIND=8), ALLOCATABLE :: cellx(:), celly(:), vertexx(:), vertexy(:)
+      INTEGER :: x_min, x_max, y_min, y_max
+   END TYPE field_type
+
+   TYPE tile_type
+      TYPE(field_type):: field
+
+      INTEGER         :: left            &
+         ,right           &
+         ,bottom          &
+         ,top
+
+      INTEGER            :: x_cells              &
+         ,y_cells
+
+      INTEGER         :: tile_neighbours(4)
+      INTEGER         :: tile_coords(2)
+
+   END TYPE tile_type
+
+   TYPE chunk_type
+      INTEGER         :: task   !mpi task
+      INTEGER         :: chunk_x_min  &
+         ,chunk_y_min  &
+         ,chunk_x_max  &
+         ,chunk_y_max
+      INTEGER            :: x_cells              &
+         ,y_cells
+      INTEGER         :: left            &
+         ,right           &
+         ,bottom          &
+         ,top
+      INTEGER         :: chunk_neighbours(4)
+      REAL(KIND=8),ALLOCATABLE:: left_rcv_buffer(:),right_rcv_buffer(:),bottom_rcv_buffer(:),top_rcv_buffer(:)
+      REAL(KIND=8),ALLOCATABLE:: left_snd_buffer(:),right_snd_buffer(:),bottom_snd_buffer(:),top_snd_buffer(:)
+      TYPE(tile_type), DIMENSION(:), ALLOCATABLE :: tiles
+      INTEGER,DIMENSION(2) :: tile_dims
+      INTEGER,DIMENSION(2) :: sub_tile_dims
+      INTEGER :: halo_exchange_depth
+   END TYPE chunk_type
+
+CONTAINS
+
+   SUBROUTINE do_alloc(t, chunk)
+      INTEGER, INTENT(IN) :: t
+      TYPE(chunk_type), INTENT(INOUT) :: chunk
+
+      ALLOCATE(chunk%tiles(t)%field%energy0 &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+
+      ALLOCATE(chunk%tiles(t)%field%energy1 &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+
+      ALLOCATE(chunk%tiles(t)%field%u       &
+         (chunk%tiles(t)%field%x_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%x_max+chunk%halo_exchange_depth, &
+         chunk%tiles(t)%field%y_min-chunk%halo_exchange_depth: &
+         chunk%tiles(t)%field%y_max+chunk%halo_exchange_depth))
+
+      ALLOCATE(chunk%tiles(t)%field%cellx   (chunk%tiles(t)%field%x_min-2:chunk%tiles(t)%field%x_max+2))
+      ALLOCATE(chunk%tiles(t)%field%celly   (chunk%tiles(t)%field%y_min-2:chunk%tiles(t)%field%y_max+2))
+      ALLOCATE(chunk%tiles(t)%field%vertexx (chunk%tiles(t)%field%x_min-2:chunk%tiles(t)%field%x_max+3))
+      ALLOCATE(chunk%tiles(t)%field%vertexy (chunk%tiles(t)%field%y_min-2:chunk%tiles(t)%field%y_max+3))
+
+   END SUBROUTINE do_alloc
+
+END MODULE test_mod
+
+! CHECK: Line:            57
+! CHECK: Fundamental:     { Name: real, Extent: 4, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            63
+! CHECK: Fundamental:     { Name: real, Extent: 4, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            69
+! CHECK: Fundamental:     { Name: real, Extent: 4, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            75
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            76
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            77
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]
+
+! CHECK: Line:            78
+! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/18_full_nested_allocate.f90
+++ b/test/pass/fortran/18_full_nested_allocate.f90
@@ -94,17 +94,17 @@ END MODULE test_mod
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            75
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            76
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            77
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]
 
 ! CHECK: Line:            78
-! CHECK: Fundamental:     { Name: real, Extent: 8, Encoding: float }
+! CHECK: Fundamental:     { Name: {{real|'real\(kind=8\)'}}, Extent: 8, Encoding: float }
 ! CHECK: Qualifiers:      [ array ]

--- a/test/pass/fortran/19_pointer_alloc_1d.f90
+++ b/test/pass/fortran/19_pointer_alloc_1d.f90
@@ -1,0 +1,17 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+PROGRAM pointer_alloc_1d
+   IMPLICIT NONE
+   INTEGER, POINTER :: p_1d(:)
+   ALLOCATE(p_1d(10))
+END PROGRAM pointer_alloc_1d
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:           [ 10 ]
+! CHECK-NEXT:   Qualifiers:      [ array, ptr ]

--- a/test/pass/fortran/20_pointer_alloc_2d.f90
+++ b/test/pass/fortran/20_pointer_alloc_2d.f90
@@ -1,0 +1,17 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+PROGRAM pointer_alloc_2d
+   IMPLICIT NONE
+   REAL, POINTER :: p_2d(:,:)
+   ALLOCATE(p_2d(5, 5))
+END PROGRAM pointer_alloc_2d
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: real, Extent: 4, Encoding: float }
+! CHECK-NEXT:   Array:           [ 5, 5 ]
+! CHECK-NEXT:   Qualifiers:      [ array, ptr ]

--- a/test/pass/fortran/21_pointer_alloc_1d_opt.f90
+++ b/test/pass/fortran/21_pointer_alloc_1d_opt.f90
@@ -1,0 +1,17 @@
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE do_alloc_1d(p_1d)
+   IMPLICIT NONE
+   INTEGER, POINTER, INTENT(INOUT) :: p_1d(:)
+   ALLOCATE(p_1d(10))
+END SUBROUTINE do_alloc_1d
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: integer, Extent: 4, Encoding: signed_int }
+! CHECK-NEXT:   Array:           [ 10 ]
+! CHECK-NEXT:   Qualifiers:      [ array, ptr ]

--- a/test/pass/fortran/22_pointer_alloc_2d_opt.f90
+++ b/test/pass/fortran/22_pointer_alloc_2d_opt.f90
@@ -1,0 +1,17 @@
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE do_alloc_2d(p_2d)
+   IMPLICIT NONE
+   REAL, POINTER, INTENT(INOUT) :: p_2d(:,:)
+   ALLOCATE(p_2d(5, 5))
+END SUBROUTINE do_alloc_2d
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: real, Extent: 4, Encoding: float }
+! CHECK-NEXT:   Array:           [ 5, 5 ]
+! CHECK-NEXT:   Qualifiers:      [ array, ptr ]

--- a/test/pass/fortran/23_char_alloc.f90
+++ b/test/pass/fortran/23_char_alloc.f90
@@ -1,0 +1,16 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE do_char_alloc(s)
+   IMPLICIT NONE
+   CHARACTER(LEN=:), ALLOCATABLE, INTENT(INOUT) :: s
+   ALLOCATE(CHARACTER(LEN=15) :: s)
+END SUBROUTINE do_char_alloc
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            9
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: character, Extent: 1, Encoding: string }

--- a/test/pass/fortran/24_char_member_alloc.f90
+++ b/test/pass/fortran/24_char_member_alloc.f90
@@ -1,0 +1,22 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+MODULE m
+   TYPE :: t
+      CHARACTER(LEN=:), ALLOCATABLE :: s
+   END TYPE
+END MODULE
+
+PROGRAM char_member_alloc
+   USE m
+   IMPLICIT NONE
+   TYPE(t) :: x
+   ALLOCATE(CHARACTER(LEN=20) :: x%s)
+END PROGRAM char_member_alloc
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            15
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: character, Extent: 1, Encoding: string }

--- a/test/pass/fortran/25_char_fixed_stack.f90
+++ b/test/pass/fortran/25_char_fixed_stack.f90
@@ -1,0 +1,16 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE use_local_char()
+   IMPLICIT NONE
+   CHARACTER(LEN=32), VOLATILE :: local_stack_char
+   local_stack_char = "ABC"
+END SUBROUTINE use_local_char
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            8
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: character, Extent: 32, Encoding: string }

--- a/test/pass/fortran/26_char_member_fixed_alloc.f90
+++ b/test/pass/fortran/26_char_member_fixed_alloc.f90
@@ -1,0 +1,23 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+MODULE m_fixed
+   TYPE :: t_fixed
+      CHARACTER(LEN=20), ALLOCATABLE :: s_fixed
+   END TYPE
+END MODULE
+
+SUBROUTINE char_member_fixed_alloc(x)
+   USE m_fixed
+   IMPLICIT NONE
+   TYPE(t_fixed), INTENT(INOUT) :: x
+   ALLOCATE(x%s_fixed)
+END SUBROUTINE char_member_fixed_alloc
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            16
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: character, Extent: 1, Encoding: string }

--- a/test/pass/fortran/27_char_fixed_stack_pass.f90
+++ b/test/pass/fortran/27_char_fixed_stack_pass.f90
@@ -1,0 +1,23 @@
+! RUN: %fortran-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+! RUN: %fortran-to-llvm %s | %opt -O2 | %apply-verifier 2>&1 | %filecheck %s
+
+! REQUIRES: hasflang
+
+SUBROUTINE print_string(s)
+   IMPLICIT NONE
+   CHARACTER(LEN=20), INTENT(IN) :: s
+   PRINT *, s
+END SUBROUTINE print_string
+
+SUBROUTINE test_fixed_char()
+   IMPLICIT NONE
+   CHARACTER(LEN=20) :: local_char
+   local_char = "Hello World"
+   CALL print_string(local_char)
+END SUBROUTINE test_fixed_char
+
+! CHECK: SourceLoc:
+! CHECK:   Line:            14
+! CHECK-NEXT: Builtin:         true
+! CHECK-NEXT: Type:
+! CHECK-NEXT:   Fundamental:     { Name: character, Extent: 20, Encoding: string }

--- a/test/pass/gep/array_composite.c
+++ b/test/pass/gep/array_composite.c
@@ -12,8 +12,15 @@ struct A {
 };
 
 void foo(struct A* ar) {
-  // CHECK: Extracted Type: {{.*}} = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[DIREF:![0-9]+]], size: 64)
-  // CHECK: Final Type: [[DIREF]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "B"
-  // CHECK-NEXT: Pointer level: 1
   ar->a[1] = (struct B*)malloc(sizeof(struct B));
 }
+
+// CHECK: SourceLoc:
+// CHECK:   Line:            15
+// CHECK: Builtin:         false
+// CHECK-NEXT: Type:
+// CHECK-NEXT:   Compound:
+// CHECK-NEXT:     Name:            B
+// CHECK-NEXT:     Type:            struct
+// CHECK-NEXT:     Extent:          0
+// CHECK-NEXT:   Qualifiers:      [ ptr ]

--- a/test/pass/ir/02_mpicxx.ll
+++ b/test/pass/ir/02_mpicxx.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK: SourceLoc:
 ; CHECK-NEXT:   File:            '/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/datatype_inln.h'

--- a/test/pass/ir/03_lulesh_ad.ll
+++ b/test/pass/ir/03_lulesh_ad.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/04_lulesh_ad_gep.ll
+++ b/test/pass/ir/04_lulesh_ad_gep.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/05_vector_copy_return.ll
+++ b/test/pass/ir/05_vector_copy_return.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/06_amg_llvm_19.ll
+++ b/test/pass/ir/06_amg_llvm_19.ll
@@ -1,6 +1,6 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
 ; CHECK-NOT: Assertion
-; REQUIRES: llvm-19 || llvm-20
+; REQUIRES: llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/test/pass/ir/07_tbaa_offset_16.ll
+++ b/test/pass/ir/07_tbaa_offset_16.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-19 || llvm-20) && tbaa
+; REQUIRES: (llvm-19 || llvm-20 || llvm-21 || llvm-22) && tbaa
 ; CHECK-NOT: Assertion
 
 ; CHECK:   Line:            32

--- a/test/pass/ir/08_tbaa_offset_8.ll
+++ b/test/pass/ir/08_tbaa_offset_8.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-19 || llvm-20) && tbaa
+; REQUIRES: (llvm-19 || llvm-20 || llvm-21 || llvm-22) && tbaa
 ; CHECK-NOT: Assertion
 
 ; CHECK:   Line:            32

--- a/test/pass/ir/09_lulesh_ad_gep_static_member.ll
+++ b/test/pass/ir/09_lulesh_ad_gep_static_member.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44
 ; CHECK: Extracted Type: !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)

--- a/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
+++ b/test/pass/ir/10_lulesh_ad_tbaa_static_member.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: (llvm-18 || llvm-19 || llvm-20) && tbaa
+; REQUIRES: (llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22) && tbaa
 
 
 ; CHECK: Type for heap-like:   %call = call ptr @realloc(), !dbg !44

--- a/test/pass/ir/11_unroll_quark_milc.ll
+++ b/test/pass/ir/11_unroll_quark_milc.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK-COUNT-7: Location: "{{.*}}quark_stuff.c":"eo_fermion_force_3f":1293
 

--- a/test/pass/ir/12_dse_debug_assign.ll
+++ b/test/pass/ir/12_dse_debug_assign.ll
@@ -1,5 +1,5 @@
 ; RUN: %apply-verifier %s |& %filecheck %s
-; REQUIRES: llvm-18 || llvm-19 || llvm-20
+; REQUIRES: llvm-18 || llvm-19 || llvm-20 || llvm-21 || llvm-22
 
 ; CHECK: Final Type Stack: !{{.*}} = !DIBasicType(name: "int",
 

--- a/test/verifier/TestPass.cpp
+++ b/test/verifier/TestPass.cpp
@@ -28,7 +28,11 @@
 #include "llvm/IR/Value.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_MAJOR < 22
 #include "llvm/Passes/PassPlugin.h"
+#else
+#include "llvm/Plugins/PassPlugin.h"
+#endif
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"


### PR DESCRIPTION
Version & Compatibility
- Bumped project version to 0.5.0
- Added support for LLVM 21 & 22 (docs + CI updated)

Fortran Support (initial)
- Added DIFortranTypeExtractor for flang debug metadata
- New DIMETA_ENABLE_FLANG CMake option (opt-in)
- Basic allocation tracking + regression tests

Architecture
- Separated DIPath / ValuePath
- Improved GEP/type resolution
- Updated dataflow for Fortran-like memory patterns

Utilities & Improvements
- New DIUtil predicates
- Reduced build verbosity by default