### PR TITLE
Enable custom allocators

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ entry:
    Using the root type, we analyze the rest of the instruction to refine the `DIType`: The `getelementptr` instruction determines the LHS of the assignment. By using the access indices `0 0`, we trace through the debug metadata of the root node (`!16`) and identify that it points to the member pointer `!18`, which has the base type `int` (`!19`).
 
 
+#### 1.3.1 Configuring `CallBase` type queries
+
+`type_for(const llvm::CallBase*)` and `located_type_for(const llvm::CallBase*)` only type known allocators registered in [MemoryOps.h](lib/type/MemoryOps.h).
+
+Use `CallBaseTypeConfig` to apply explicit dataflow semantics to custom/unknown allocation APIs:
+
+```cpp
+if (const auto* call = llvm::dyn_cast<llvm::CallBase>(&inst)) {
+  // Strict mode: unknown calls are rejected.
+  auto auto_type = dimeta::located_type_for(call);
+  // CUDA/MPI-like API: backtrack from a specific argument.
+  dimeta::CallBaseTypeConfig arg_cfg;
+  arg_cfg.dataflow = dimeta::CallBaseTypeConfig::Dataflow::kArgumentBackward;
+  arg_cfg.argument_index = 0;  // use 2 for MPI_Alloc_mem-like APIs
+  auto arg_type = dimeta::located_type_for(call, arg_cfg);
+  // malloc-like API: follow return value forward, then backtrack.
+  dimeta::CallBaseTypeConfig ret_cfg;
+  ret_cfg.dataflow = dimeta::CallBaseTypeConfig::Dataflow::kReturnValueForwardThenBackward;
+  auto ret_type = dimeta::located_type_for(call, ret_cfg);
+}
+```
+
 ## 2. Building llvm-dimeta
 
 llvm-dimeta is tested with LLVM version 13-15 and 18-22, and CMake version >= 3.20. Use CMake presets `develop` or `release` to build.
@@ -168,4 +190,3 @@ $> cmake --build build --target check-dimeta
     pages 116-121. IEEE, 2025. DOI: <a href="https://doi.org/10.1109/SCAM67354.2025.00019">10.1109/SCAM67354.2025.00019</a></td>
 </tr>
 </table>
-

--- a/lib/type/DataflowAnalysis.cpp
+++ b/lib/type/DataflowAnalysis.cpp
@@ -89,7 +89,10 @@ llvm::SmallVector<ValuePath, 4> type_for_heap_call(const llvm::CallBase* call) {
   MallocTargetMatcher malloc_anchor_backtrack;
   MallocBacktrackSearch backtrack_search_dir_fn;
 
-  assert(!malloc_forward_anchor_finder.anchors.empty() && "Anchor should not be empty");
+  if (malloc_forward_anchor_finder.anchors.empty()) {
+    LOG_DEBUG("No anchors found for heap-call dataflow")
+    return {};
+  }
   llvm::SmallVector<ValuePath, 4> ditype_paths;
 
   for (const auto& anchor_path : malloc_forward_anchor_finder.anchors) {

--- a/lib/type/Dimeta.cpp
+++ b/lib/type/Dimeta.cpp
@@ -71,6 +71,136 @@ namespace experimental {
 std::optional<llvm::DIType*> di_type_for(const llvm::Value* value);
 }
 
+std::optional<llvm::DIType*> type_for_malloclike(const llvm::CallBase* call);
+std::optional<llvm::DIType*> type_for_newlike(const llvm::CallBase* call);
+auto final_ditype(std::optional<llvm::DIType*> root_ditype) -> std::pair<std::optional<llvm::DIType*>, int>;
+
+namespace {
+
+enum class CallBaseTypeSource {
+  kReturnValueForwardThenBackward,
+  kArgumentBackward,
+  kFortranDescriptor,
+  kHeapAllocSite,
+};
+
+struct ResolvedCallBaseTypeConfig {
+  CallBaseTypeSource source;
+  unsigned argument_index{0};
+  int pointer_level_offset{0};
+};
+
+std::optional<ResolvedCallBaseTypeConfig> resolve_auto_callbase_config(const llvm::CallBase* call) {
+  if (call == nullptr) {
+    return {};
+  }
+
+  auto* cb_fun = call->getCalledFunction();
+  if (cb_fun == nullptr) {
+    return {};
+  }
+
+  const dimeta::memory::MemOps mem_ops;
+  if (!mem_ops.isAlloc(cb_fun->getName())) {
+    LOG_TRACE("Skipping call base: " << cb_fun->getName());
+    return {};
+  }
+
+  if (mem_ops.isFortranLike(cb_fun->getName())) {
+    return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kFortranDescriptor, 0, 0};
+  }
+
+  if (mem_ops.isCudaLike(cb_fun->getName())) {
+    return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kArgumentBackward, 0, 0};
+  }
+
+  if (mem_ops.isMpiLike(cb_fun->getName())) {
+    return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kArgumentBackward, 2, 0};
+  }
+
+#ifdef DIMETA_USE_HEAPALLOCSITE
+  if (mem_ops.isNewLike(cb_fun->getName()) && call->getMetadata("heapallocsite") != nullptr) {
+    return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kHeapAllocSite, 0, 1};
+  }
+#endif
+
+  return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kReturnValueForwardThenBackward, 0, 0};
+}
+
+std::optional<ResolvedCallBaseTypeConfig> resolve_callbase_config(const llvm::CallBase* call,
+                                                                  const CallBaseTypeConfig& config) {
+  if (call == nullptr) {
+    return {};
+  }
+
+  if (config.dataflow == CallBaseTypeConfig::Dataflow::kAuto) {
+    return resolve_auto_callbase_config(call);
+  }
+
+  if (config.dataflow == CallBaseTypeConfig::Dataflow::kArgumentBackward) {
+    if (config.argument_index >= call->arg_size()) {
+      LOG_DEBUG("Invalid argument index for callbase config: " << config.argument_index);
+      return {};
+    }
+    return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kArgumentBackward, config.argument_index,
+                                      config.pointer_level_offset};
+  }
+
+  if (config.dataflow == CallBaseTypeConfig::Dataflow::kReturnValueForwardThenBackward) {
+    return ResolvedCallBaseTypeConfig{CallBaseTypeSource::kReturnValueForwardThenBackward, 0,
+                                      config.pointer_level_offset};
+  }
+
+  return {};
+}
+
+std::optional<DimetaData> type_for_resolved_callbase(const llvm::CallBase* call,
+                                                     const ResolvedCallBaseTypeConfig& config) {
+  if (call == nullptr) {
+    return {};
+  }
+
+  std::optional<llvm::DIType*> extracted_type{};
+  std::optional<ShapeData> shape_type{};
+  int pointer_level_offset{config.pointer_level_offset};
+
+  switch (config.source) {
+    case CallBaseTypeSource::kArgumentBackward: {
+      extracted_type = experimental::di_type_for(call->getArgOperand(config.argument_index));
+      break;
+    }
+    case CallBaseTypeSource::kReturnValueForwardThenBackward: {
+      extracted_type = type_for_malloclike(call);
+      break;
+    }
+    case CallBaseTypeSource::kFortranDescriptor: {
+      if (call->arg_size() == 0) {
+        return {};
+      }
+      auto fortran_type = fortran::di_type_for(call->getArgOperand(0), call);
+      if (fortran_type) {
+        extracted_type = fortran_type->type;
+        if (fortran_type->shape_argument) {
+          shape_type = fortran_type->shape_argument;
+        }
+      }
+      break;
+    }
+    case CallBaseTypeSource::kHeapAllocSite: {
+      extracted_type = type_for_newlike(call);
+      break;
+    }
+  }
+
+  auto source_loc                        = difinder::find_location(call);
+  const auto [final_type, pointer_level] = final_ditype(extracted_type);
+
+  return DimetaData{DimetaData::MemLoc::kHeap,           {}, extracted_type, final_type, source_loc, shape_type,
+                    pointer_level + pointer_level_offset};
+}
+
+}  // namespace
+
 llvm::SmallVector<llvm::DIType*, 4> collect_types(const llvm::CallBase* call,
                                                   llvm::ArrayRef<dataflow::ValuePath> paths_to_type) {
   using namespace llvm;
@@ -138,86 +268,28 @@ std::optional<llvm::DIType*> type_for_newlike(const llvm::CallBase* call) {
   return {};
 }
 
-std::optional<DimetaData> type_for(const llvm::CallBase* call) {
-  using namespace llvm;
-  const dimeta::memory::MemOps mem_ops;
-
-  auto* cb_fun = call->getCalledFunction();
-  if (!cb_fun) {
-    return {};
-  }
-
-  if (!mem_ops.isAlloc(cb_fun->getName())) {
-    LOG_TRACE("Skipping call base: " << cb_fun->getName());
-    return {};
-  }
-
-  std::optional<llvm::DIType*> extracted_type{};
-  std::optional<ShapeData> shape_type{};
-  int pointer_level_offset{0};
-
-  const auto is_fortran_like = mem_ops.isFortranLike(cb_fun->getName());
-  if (is_fortran_like) {
-    LOG_DEBUG("Type for fortran-like " << cb_fun->getName())
-    auto fortran_type = fortran::di_type_for(call->getOperand(0), call);
-    if (fortran_type) {
-      extracted_type = fortran_type->type;
-      if (fortran_type->shape_argument) {
-        shape_type = fortran_type->shape_argument;
-      }
-    }
-  }
-
-  const auto is_cuda_like = mem_ops.isCudaLike(cb_fun->getName());
-  if (is_cuda_like) {
-    LOG_DEBUG("Type for cuda-like " << cb_fun->getName())
-    extracted_type = experimental::di_type_for(call->getOperand(0));
-
-    // when wrapped in, e.g., cudaMalloc<float>(float**, ...), we remove one pointer level:
-    // auto* parent    = call->getFunction();
-    // const auto name = std::string{cb_fun->getName()} + "<";
-    // LOG_DEBUG(name << " vs. " << util::try_demangle(*makeparent))
-    // if (extracted_type && util::try_demangle(*parent).find(name) != std::string::npos) {
-    //   LOG_DEBUG("Reset cuda-like pointer level")
-    //   auto ditype = llvm::dyn_cast<llvm::DIDerivedType>(extracted_type.value());
-    //   if (ditype->getTag() == llvm::dwarf::DW_TAG_pointer_type) {
-    //     extracted_type = ditype->getBaseType();
-    //   }
-    // }
-  }
-
-  const auto is_mpi_like = mem_ops.isMpiLike(cb_fun->getName());
-  if (is_mpi_like) {
-    LOG_DEBUG("Type for MPI-like " << cb_fun->getName())
-    extracted_type = experimental::di_type_for(call->getOperand(2));
-  }
-
-  const auto is_cxx_new = mem_ops.isNewLike(cb_fun->getName());
-
-#ifdef DIMETA_USE_HEAPALLOCSITE
-  if (is_cxx_new) {
-    if (call->getMetadata("heapallocsite")) {
-      LOG_TRACE("Type for new-like " << cb_fun->getName())
-      extracted_type = type_for_newlike(call);
-      // !heapallocsite gives the type after "new", i.e., new int -> int, new int*[n] -> int*.
-      // Our malloc-related algorithm would return int* and int** respectively, however, hence:
-      pointer_level_offset += 1;
+std::optional<DimetaData> type_for(const llvm::CallBase* call, const CallBaseTypeConfig& config) {
+  auto resolved = resolve_callbase_config(call, config);
+  if (!resolved) {
+    if (config.dataflow == CallBaseTypeConfig::Dataflow::kAuto) {
+      LOG_TRACE("Skipping call base in auto mode.");
     } else {
-      LOG_DEBUG("new-like allocation does not have heapallocsite metadata.")
+      LOG_DEBUG("Could not resolve explicit callbase type configuration.");
     }
+    return {};
   }
-#endif
 
-  if (!extracted_type) {
-    LOG_DEBUG("Type for malloc-like: " << cb_fun->getName())
-    extracted_type = type_for_malloclike(call);
+  auto result = type_for_resolved_callbase(call, *resolved);
+  if (!result) {
+    return {};
   }
-  auto source_loc                        = difinder::find_location(call);
-  const auto [final_type, pointer_level] = final_ditype(extracted_type);
-  const auto meta =
-      DimetaData{DimetaData::MemLoc::kHeap,           {}, extracted_type, final_type, source_loc, shape_type,
-                 pointer_level + pointer_level_offset};
-  return meta;
+
+  if (config.dataflow != CallBaseTypeConfig::Dataflow::kAuto && !result->entry_type) {
+    LOG_DEBUG("Explicit callbase type extraction failed.");
+    return {};
+  }
+
+  return result;
 }
 
 std::optional<DimetaData> type_for(const llvm::AllocaInst* ai) {

--- a/lib/type/Dimeta.h
+++ b/lib/type/Dimeta.h
@@ -10,6 +10,7 @@
 
 #include "DimetaData.h"
 
+#include <cstdint>
 #include <optional>
 #include <variant>
 
@@ -49,9 +50,21 @@ struct DimetaData {
   int pointer_level{0};                            // e.g., 1 -> int*, 2 -> int**, etc.
 };
 
+struct CallBaseTypeConfig {
+  enum class Dataflow : std::int8_t {
+    kAuto,
+    kReturnValueForwardThenBackward,
+    kArgumentBackward,
+  };
+
+  Dataflow dataflow{Dataflow::kAuto};
+  unsigned argument_index{0};
+  int pointer_level_offset{0};
+};
+
 std::optional<DimetaData> type_for(const llvm::AllocaInst*);
 
-std::optional<DimetaData> type_for(const llvm::CallBase*);
+std::optional<DimetaData> type_for(const llvm::CallBase*, const CallBaseTypeConfig& config = CallBaseTypeConfig{});
 
 std::optional<DimetaData> type_for(const llvm::GlobalVariable*);
 
@@ -61,7 +74,8 @@ std::optional<LocatedType> located_type_for(const DimetaData&);
 
 std::optional<LocatedType> located_type_for(const llvm::AllocaInst*);
 
-std::optional<LocatedType> located_type_for(const llvm::CallBase*);
+std::optional<LocatedType> located_type_for(const llvm::CallBase*,
+                                            const CallBaseTypeConfig& config = CallBaseTypeConfig{});
 
 std::optional<LocatedType> located_type_for(const llvm::GlobalVariable*);
 

--- a/lib/type/SourceLocType.cpp
+++ b/lib/type/SourceLocType.cpp
@@ -165,8 +165,13 @@ std::optional<LocatedType> located_type_for(const llvm::AllocaInst* ai) {
   return get_located_type(ai);
 }
 
-std::optional<LocatedType> located_type_for(const llvm::CallBase* cb) {
-  return get_located_type(cb);
+std::optional<LocatedType> located_type_for(const llvm::CallBase* cb, const CallBaseTypeConfig& config) {
+  auto type_data = type_for(cb, config);
+  if (!type_data) {
+    LOG_DEBUG("Could not determine type.");
+    return {};
+  }
+  return located_type_for(type_data.value());
 }
 
 std::optional<LocatedType> located_type_for(const llvm::GlobalVariable* gv) {

--- a/test/pass/call/unknown_alloc_argument_backward_cuda_like.c
+++ b/test/pass/call/unknown_alloc_argument_backward_cuda_like.c
@@ -1,8 +1,7 @@
-// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
-// RUN: %c-to-llvm %s | %opt -O2 -S | %apply-verifier 2>&1 | %filecheck %s
 // RUN: %c-to-llvm %s | %apply-verifier -callbase-mode=argument-backward -callbase-arg=0 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier -callbase-mode=argument-backward -callbase-arg=0 2>&1 | %filecheck %s
 
-extern int cudaMalloc(void** devPtr, int size);
+extern int custom_cuda_alloc(void** devPtr, int size);
 
 int* d_p;
 
@@ -10,5 +9,5 @@ void foo(int n) {
   // CHECK: Extracted Type: {{.*}} = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[DIREF:![0-9]+]], size: 64)
   // CHECK: Final Type: [[DIREF]] = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
   // CHECK: Location: "{{.*}}":"foo":[[@LINE+1]]
-  cudaMalloc((void**)&d_p, sizeof(int) * n);
+  custom_cuda_alloc((void**)&d_p, sizeof(int) * n);
 }

--- a/test/pass/call/unknown_alloc_argument_backward_cuda_like.c
+++ b/test/pass/call/unknown_alloc_argument_backward_cuda_like.c
@@ -1,5 +1,6 @@
 // RUN: %c-to-llvm %s | %apply-verifier -callbase-mode=argument-backward -callbase-arg=0 2>&1 | %filecheck %s
-// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier -callbase-mode=argument-backward -callbase-arg=0 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier -callbase-mode=argument-backward -callbase-arg=0 2>&1 | \
+// RUN: %filecheck %s
 
 extern int custom_cuda_alloc(void** devPtr, int size);
 

--- a/test/pass/call/unknown_alloc_argument_backward_wrong_arg.c
+++ b/test/pass/call/unknown_alloc_argument_backward_wrong_arg.c
@@ -1,0 +1,12 @@
+// RUN: %c-to-llvm %s | %apply-verifier -callbase-mode=argument-backward -callbase-arg=1 2>&1 | %filecheck %s
+
+extern int custom_cuda_alloc(void** devPtr, int size);
+
+int* d_p;
+
+void foo(int n) {
+  custom_cuda_alloc((void**)&d_p, sizeof(int) * n);
+}
+
+// CHECK: Function: foo:
+// CHECK-NOT: Type for heap-like: {{.*}}@custom_cuda_alloc

--- a/test/pass/call/unknown_alloc_auto_reject.c
+++ b/test/pass/call/unknown_alloc_auto_reject.c
@@ -1,0 +1,12 @@
+// RUN: %c-to-llvm %s | %apply-verifier 2>&1 | %filecheck %s
+
+extern void* custom_alloc(int size);
+
+int* p;
+
+void foo(int n) {
+  p = (int*)custom_alloc(sizeof(int) * n);
+}
+
+// CHECK: Function: foo:
+// CHECK-NOT: Type for heap-like: {{.*}}@custom_alloc

--- a/test/pass/call/unknown_alloc_return_flow.c
+++ b/test/pass/call/unknown_alloc_return_flow.c
@@ -1,0 +1,13 @@
+// RUN: %c-to-llvm %s | %apply-verifier -callbase-mode=return-flow 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %opt -O1 -S | %apply-verifier -callbase-mode=return-flow 2>&1 | %filecheck %s
+
+extern void* custom_alloc(int size);
+
+int* p;
+
+void foo(int n) {
+  // CHECK: Extracted Type: {{.*}} = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[DIREF:![0-9]+]], size: 64)
+  // CHECK: Final Type: [[DIREF]] = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  // CHECK: Location: "{{.*}}":"foo":[[@LINE+1]]
+  p = (int*)custom_alloc(sizeof(int) * n);
+}

--- a/test/verifier/TestPass.cpp
+++ b/test/verifier/TestPass.cpp
@@ -42,10 +42,13 @@
 #include <iterator>
 #include <llvm/IR/Instruction.h>
 #include <llvm/Support/YAMLTraits.h>
+#include <cerrno>
+#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 namespace llvm {
 class PointerType;
@@ -59,6 +62,8 @@ static cl::opt<bool> cl_dimeta_test_print_tree("dump-tree", cl::init(false));
 static cl::opt<bool> cl_dimeta_test_stack_pointer("stack-pointer-skip", cl::init(false));
 static cl::opt<bool> cl_dimeta_test_print("dump", cl::init(false));
 static cl::opt<bool> cl_dimeta_test_kernel_call("kernel-call", cl::init(false));
+static cl::opt<std::string> cl_dimeta_test_callbase_mode("callbase-mode", cl::init("auto"));
+static cl::opt<unsigned> cl_dimeta_test_callbase_arg("callbase-arg", cl::init(0));
 
 namespace dimeta::test {
 
@@ -147,6 +152,34 @@ bool variable_is_toggled(const T& var, std::string_view env_name) {
   const char* env_value = std::getenv(env_name.data());
   if (env_value != nullptr) {
     return std::string_view{env_value}.compare("1") == 0;
+  }
+  return var.getValue();
+}
+
+inline std::string variable_or_env_string(const cl::opt<std::string>& var, std::string_view env_name) {
+  if (var.getNumOccurrences() > 0) {
+    return var.getValue();
+  }
+  const char* env_value = std::getenv(env_name.data());
+  if (env_value != nullptr) {
+    return env_value;
+  }
+  return var.getValue();
+}
+
+inline unsigned variable_or_env_unsigned(const cl::opt<unsigned>& var, std::string_view env_name) {
+  if (var.getNumOccurrences() > 0) {
+    return var.getValue();
+  }
+  const char* env_value = std::getenv(env_name.data());
+  if (env_value != nullptr) {
+    char* end_ptr = nullptr;
+    errno         = 0;
+    auto value    = std::strtoul(env_value, &end_ptr, 10);
+    if (errno == 0 && end_ptr != env_value && *end_ptr == '\0') {
+      return static_cast<unsigned>(value);
+    }
+    return var.getValue();
   }
   return var.getValue();
 }
@@ -240,8 +273,45 @@ class TestPass : public llvm::PassInfoMixin<TestPass> {
 
     LOG_MSG("\nFunction: " << f_name << ":");
 
+    const auto callbase_mode = util::variable_or_env_string(cl_dimeta_test_callbase_mode, "DIMETA_TEST_CALLBASE_MODE");
+    const auto callbase_arg  = util::variable_or_env_unsigned(cl_dimeta_test_callbase_arg, "DIMETA_TEST_CALLBASE_ARG");
+
+    const auto make_callbase_config = [&]() -> std::optional<CallBaseTypeConfig> {
+      if (callbase_mode == "auto") {
+        return {};
+      }
+
+      CallBaseTypeConfig config;
+      config.argument_index = callbase_arg;
+
+      if (callbase_mode == "return-flow") {
+        config.dataflow = CallBaseTypeConfig::Dataflow::kReturnValueForwardThenBackward;
+        return config;
+      }
+
+      if (callbase_mode == "argument-backward") {
+        config.dataflow = CallBaseTypeConfig::Dataflow::kArgumentBackward;
+        return config;
+      }
+
+      LOG_ERROR("Unsupported callbase mode: " << callbase_mode)
+      return {};
+    }();
+
     const auto get_located_type = [&](auto* call_inst) -> std::optional<LocatedType> {
-      auto located_type = located_type_for(call_inst);
+      auto located_type = [&]() -> std::optional<LocatedType> {
+        if constexpr (std::is_same_v<std::remove_pointer_t<decltype(call_inst)>, llvm::CallBase>) {
+          if (callbase_mode == "auto") {
+            return located_type_for(call_inst);
+          }
+          if (!make_callbase_config) {
+            return {};
+          }
+          return located_type_for(call_inst, make_callbase_config.value());
+        }
+        return located_type_for(call_inst);
+      }();
+
       if (located_type) {
         LOG_DEBUG(util::print_loc(located_type->location));
         return located_type;
@@ -286,8 +356,17 @@ class TestPass : public llvm::PassInfoMixin<TestPass> {
 
     for (auto& inst : llvm::instructions(func)) {
       if (auto* call_inst = dyn_cast<CallBase>(&inst)) {
-        auto ditype_meta = type_for(call_inst);
-        if (ditype_meta) {
+        auto ditype_meta = [&]() -> std::optional<DimetaData> {
+          if (callbase_mode == "auto") {
+            return type_for(call_inst);
+          }
+          if (!make_callbase_config) {
+            return {};
+          }
+          return type_for(call_inst, make_callbase_config.value());
+        }();
+
+        if (ditype_meta && ditype_meta->entry_type) {
           LOG_DEBUG("Type for heap-like: " << *call_inst)
           LOG_DEBUG(util::to_string(ditype_meta.value()) << "\n");
           // auto result = located_type_for(ditype_meta.value());

--- a/test/verifier/TestPass.cpp
+++ b/test/verifier/TestPass.cpp
@@ -38,12 +38,12 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cerrno>
+#include <cstdlib>
 #include <iomanip>
 #include <iterator>
 #include <llvm/IR/Instruction.h>
 #include <llvm/Support/YAMLTraits.h>
-#include <cerrno>
-#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <string>

--- a/test/verifier/opt-shim.in
+++ b/test/verifier/opt-shim.in
@@ -49,6 +49,22 @@ function dimeta_test_parse_cmd_line_fn() {
       fi
       shift
     ;;
+    -callbase-mode=*)
+      if [ "@NEW_PM_REQUIRED@" ==  "1" ]; then
+        export DIMETA_TEST_CALLBASE_MODE="${1#*=}"
+      else
+        dimeta_test_pass_wrapper_more_args+=" $1"
+      fi
+      shift
+    ;;
+    -callbase-arg=*)
+      if [ "@NEW_PM_REQUIRED@" ==  "1" ]; then
+        export DIMETA_TEST_CALLBASE_ARG="${1#*=}"
+      else
+        dimeta_test_pass_wrapper_more_args+=" $1"
+      fi
+      shift
+    ;;
     -instcombine)
       if [ "@NEW_PM_REQUIRED@" ==  "1" ]; then
         dimeta_test_pass_wrapper_more_args+=" -passes=instcombine"    


### PR DESCRIPTION
Detection modes
- auto : only known allocators are analyzed (as is behavior)
- Addition: Custom config allows for "unknown" heap-allocation functions to be analyzed